### PR TITLE
Feature/refactor many to one views

### DIFF
--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -64,13 +64,6 @@ def add_related_object_for_eval(evaluation_id, model_name, redirect_url_name):
     return response
 
 
-# def add_outcome_measure(evaluation_id):
-#     evaluation = models.Evaluation.objects.get(pk=evaluation_id)
-#     outcome = models.OutcomeMeasure(evaluation=evaluation)
-#     outcome.save()
-#     return redirect(reverse("outcome-measure-page", args=(evaluation_id, outcome.id)))
-
-
 @login_required
 def initial_related_object_page_view(request, evaluation_id, model_name, form_data):
     errors = {}
@@ -106,23 +99,6 @@ def initial_outcome_measure_page_view(request, evaluation_id):
     return initial_related_object_page_view(request, evaluation_id, model_name, form_data)
 
 
-# @login_required
-# def initial_outcome_measure_page_view(request, evaluation_id):
-#     errors = {}
-#     data = {}
-#     prev_url = reverse("interventions", args=(evaluation_id,))
-#     next_url = reverse("other-measures", args=(evaluation_id,))
-#     if request.method == "POST":
-#         if "add" in request.POST:
-#             return add_outcome_measure(evaluation_id)
-#         return redirect(next_url)
-#     return render(
-#         request,
-#         "submissions/outcome-measures.html",
-#         {"title": "Outcome measures", "errors": errors, "data": data, "prev_url": prev_url, "next_url": next_url},
-#     )
-
-
 @login_required
 def first_last_related_object_view(
     request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last="first"
@@ -138,30 +114,6 @@ def first_last_related_object_view(
         response = redirect(reverse(page_url_name, args=(evaluation_id, id)))
         return response
     return redirect(reverse(initial_url_name, args=(evaluation_id,)))
-
-
-# def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first"):
-#     model_name = "OutcomeMeasure"
-#     page_url_name = "outcome-measure-page"
-#     initial_url_name = "outcome-measures"
-#     response = first_last_related_object_view(
-#         request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last
-#     )
-#     return response
-
-
-# @login_required
-# def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first"):
-#     outcomes_for_eval = models.OutcomeMeasure.objects.filter(evaluation__id=evaluation_id)
-#     if first_or_last == "first":
-#         outcomes_for_eval = outcomes_for_eval.order_by("created_at")
-#     else:
-#         outcomes_for_eval = outcomes_for_eval.order_by("-created_at")
-#     if outcomes_for_eval:
-#         outcome_id = outcomes_for_eval[0].id
-#         return redirect(reverse("outcome-measure-page", args=(evaluation_id, outcome_id)))
-#     else:
-#         return redirect(reverse("outcome-measures", args=(evaluation_id,)))
 
 
 @login_required

--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -76,7 +76,7 @@ def initial_related_object_page_view(request, evaluation_id, model_name, form_da
     errors = {}
     data = {}
     title = form_data["title"]
-    template_name = form_data["template"]
+    template_name = form_data["template_name"]
     prev_url_name = form_data["prev_url_name"]
     next_url_name = form_data["next_url_name"]
     add_url_name = form_data["add_url_name"]
@@ -124,17 +124,44 @@ def initial_outcome_measure_page_view(request, evaluation_id):
 
 
 @login_required
-def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first"):
-    outcomes_for_eval = models.OutcomeMeasure.objects.filter(evaluation__id=evaluation_id)
+def first_last_related_object_view(
+    request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last="first"
+):
+    model = getattr(models, model_name)
+    related_objects_for_eval = model.objects.filter(evaluation__id=evaluation_id)
     if first_or_last == "first":
-        outcomes_for_eval = outcomes_for_eval.order_by("created_at")
+        related_objects_for_eval = related_objects_for_eval.order_by("created_at")
     else:
-        outcomes_for_eval = outcomes_for_eval.order_by("-created_at")
-    if outcomes_for_eval:
-        outcome_id = outcomes_for_eval[0].id
-        return redirect(reverse("outcome-measure-page", args=(evaluation_id, outcome_id)))
-    else:
-        return redirect(reverse("outcome-measures", args=(evaluation_id,)))
+        related_objects_for_eval = related_objects_for_eval.order_by("-created_at")
+    if related_objects_for_eval:
+        id = related_objects_for_eval[0].id
+        response = redirect(reverse(page_url_name, args=(evaluation_id, id)))
+        return response
+    return redirect(reverse(initial_url_name, args=(evaluation_id,)))
+
+
+def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first"):
+    model_name = "OutcomeMeasure"
+    page_url_name = "outcome-measure-page"
+    initial_url_name = "outcome-measures"
+    response = first_last_related_object_view(
+        request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last
+    )
+    return response
+
+
+# @login_required
+# def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first"):
+#     outcomes_for_eval = models.OutcomeMeasure.objects.filter(evaluation__id=evaluation_id)
+#     if first_or_last == "first":
+#         outcomes_for_eval = outcomes_for_eval.order_by("created_at")
+#     else:
+#         outcomes_for_eval = outcomes_for_eval.order_by("-created_at")
+#     if outcomes_for_eval:
+#         outcome_id = outcomes_for_eval[0].id
+#         return redirect(reverse("outcome-measure-page", args=(evaluation_id, outcome_id)))
+#     else:
+#         return redirect(reverse("outcome-measures", args=(evaluation_id,)))
 
 
 @login_required

--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -140,14 +140,14 @@ def first_last_related_object_view(
     return redirect(reverse(initial_url_name, args=(evaluation_id,)))
 
 
-def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first"):
-    model_name = "OutcomeMeasure"
-    page_url_name = "outcome-measure-page"
-    initial_url_name = "outcome-measures"
-    response = first_last_related_object_view(
-        request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last
-    )
-    return response
+# def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first"):
+#     model_name = "OutcomeMeasure"
+#     page_url_name = "outcome-measure-page"
+#     initial_url_name = "outcome-measures"
+#     response = first_last_related_object_view(
+#         request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last
+#     )
+#     return response
 
 
 # @login_required
@@ -166,12 +166,24 @@ def first_last_outcome_measure_view(request, evaluation_id, first_or_last="first
 
 @login_required
 def first_outcome_measure_page_view(request, evaluation_id):
-    return first_last_outcome_measure_view(request, evaluation_id, first_or_last="first")
+    model_name = "OutcomeMeasure"
+    page_url_name = "outcome-measure-page"
+    initial_url_name = "outcome-measures"
+    response = first_last_related_object_view(
+        request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last="first"
+    )
+    return response
 
 
 @login_required
 def last_outcome_measure_page_view(request, evaluation_id):
-    return first_last_outcome_measure_view(request, evaluation_id, first_or_last="last")
+    model_name = "OutcomeMeasure"
+    page_url_name = "outcome-measure-page"
+    initial_url_name = "outcome-measures"
+    response = first_last_related_object_view(
+        request, evaluation_id, model_name, initial_url_name, page_url_name, first_or_last="last"
+    )
+    return response
 
 
 @login_required

--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -185,6 +185,10 @@ def evaluation_view(request, evaluation_id, page_data):
     )
 
 
+# model name, schema name, prev section page, next section page, individual page
+# title, template
+
+
 @login_required
 def outcome_measure_page_view(request, evaluation_id, outcome_measure_id):
     outcome = models.OutcomeMeasure.objects.get(id=outcome_measure_id)
@@ -240,23 +244,56 @@ def outcome_measure_page_view(request, evaluation_id, outcome_measure_id):
     )
 
 
-def delete_outcome_measure_page_view(request, evaluation_id, outcome_measure_id):
-    outcome = models.OutcomeMeasure.objects.filter(evaluation__id=evaluation_id).get(id=outcome_measure_id)
-    prev_id = get_adjacent_id_for_model(
-        evaluation_id=evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="prev"
-    )
-    next_id = get_adjacent_id_for_model(
-        evaluation_id=evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="next"
-    )
-    outcome.delete()
+@login_required
+def delete_related_object_view(request, evaluation_id, id, model_name, initial_url_name, page_url_name):
+    model = getattr(models, model_name)
+    obj_to_delete = model.objects.get(id=id)
+    prev_id = get_adjacent_id_for_model(evaluation_id=evaluation_id, id=id, model_name=model_name, next_or_prev="prev")
+    next_id = get_adjacent_id_for_model(evaluation_id=evaluation_id, id=id, model_name=model_name, next_or_prev="next")
+    obj_to_delete.delete()
 
     if prev_id:
-        next_url = reverse("outcome-measure-page", args=(evaluation_id, prev_id))
+        next_url = reverse(page_url_name, args=(evaluation_id, prev_id))
     elif next_id:
-        next_url = reverse("outcome-measure-page", args=(evaluation_id, next_id))
+        next_url = reverse(page_url_name, args=(evaluation_id, next_id))
     else:
-        next_url = reverse("outcome-measures", args=(evaluation_id,))
+        next_url = reverse(initial_url_name, args=(evaluation_id,))
     return redirect(next_url)
+
+
+def delete_outcome_measure_page_view(request, evaluation_id, outcome_measure_id):
+    model_name = "OutcomeMeasure"
+    initial_url_name = "outcome-measures"
+    page_url_name = "outcome-measure-page"
+    evaluation_id, id, model_name, initial_url_name, page_url_name
+    response = delete_related_object_view(
+        request,
+        evaluation_id=evaluation_id,
+        id=outcome_measure_id,
+        model_name=model_name,
+        initial_url_name=initial_url_name,
+        page_url_name=page_url_name,
+    )
+    return response
+
+
+# def delete_outcome_measure_page_view(request, evaluation_id, outcome_measure_id):
+#     outcome = models.OutcomeMeasure.objects.filter(evaluation__id=evaluation_id).get(id=outcome_measure_id)
+#     prev_id = get_adjacent_id_for_model(
+#         evaluation_id=evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="prev"
+#     )
+#     next_id = get_adjacent_id_for_model(
+#         evaluation_id=evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="next"
+#     )
+#     outcome.delete()
+
+#     if prev_id:
+#         next_url = reverse("outcome-measure-page", args=(evaluation_id, prev_id))
+#     elif next_id:
+#         next_url = reverse("outcome-measure-page", args=(evaluation_id, next_id))
+#     else:
+#         next_url = reverse("outcome-measures", args=(evaluation_id,))
+#     return redirect(next_url)
 
 
 def intro_page_view(request, evaluation_id):

--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -185,65 +185,6 @@ def evaluation_view(request, evaluation_id, page_data):
     )
 
 
-# @login_required
-# def outcome_measure_page_view(request, evaluation_id, outcome_measure_id):
-#     outcome = models.OutcomeMeasure.objects.get(id=outcome_measure_id)
-#     outcome_schema = schemas.OutcomeMeasureSchema(unknown=marshmallow.EXCLUDE)
-#     errors = {}
-#     data = {}
-#     show_add = False
-#     next_outcome_id = get_adjacent_id_for_model(
-#         evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="next"
-#     )
-#     prev_outcome_id = get_adjacent_id_for_model(
-#         evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="prev"
-#     )
-#     if next_outcome_id:
-#         next_url = reverse("outcome-measure-page", args=(evaluation_id, next_outcome_id))
-#     else:
-#         next_url = reverse("other-measures", args=(evaluation_id,))
-#         show_add = True
-#     if prev_outcome_id:
-#         prev_url = reverse("outcome-measure-page", args=(evaluation_id, prev_outcome_id))
-#     else:
-#         prev_url = reverse("interventions", args=(evaluation_id,))
-#     if request.method == "POST":
-#         data = request.POST
-#         try:
-#             if "delete" in request.POST:
-#                 delete_url = reverse("outcome-measure-delete", args=(evaluation_id, outcome_measure_id))
-#                 return redirect(delete_url)
-#             serialized_outcome = outcome_schema.load(data=data, partial=True)
-#             for field_name in serialized_outcome:
-#                 setattr(outcome, field_name, serialized_outcome[field_name])
-#             outcome.save()
-#             if "add" in request.POST:
-#                 return add_related_object_for_eval(
-#                     evaluation_id, model_name="OutcomeMeasure", redirect_url_name="outcome-measure-page"
-#                 )
-#             return redirect(next_url)
-#         except marshmallow.exceptions.ValidationError as err:
-#             errors = dict(err.messages)
-#     else:
-#         data = outcome_schema.dump(outcome)
-#     return render(
-#         request,
-#         "submissions/outcome-measure-page.html",
-#         {
-#             "title": "Outcome measures",
-#             "errors": errors,
-#             "data": data,
-#             "next_url": next_url,
-#             "prev_url": prev_url,
-#             "show_add": show_add,
-#         },
-#     )
-
-
-# model name, schema name, prev section page, next section page, individual page
-# title, template
-
-
 @login_required
 def related_object_page_view(request, evaluation_id, id, model_name, title, template_name, url_names):
     model = getattr(models, model_name)
@@ -350,25 +291,6 @@ def delete_outcome_measure_page_view(request, evaluation_id, outcome_measure_id)
         page_url_name=page_url_name,
     )
     return response
-
-
-# def delete_outcome_measure_page_view(request, evaluation_id, outcome_measure_id):
-#     outcome = models.OutcomeMeasure.objects.filter(evaluation__id=evaluation_id).get(id=outcome_measure_id)
-#     prev_id = get_adjacent_id_for_model(
-#         evaluation_id=evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="prev"
-#     )
-#     next_id = get_adjacent_id_for_model(
-#         evaluation_id=evaluation_id, id=outcome_measure_id, model_name="OutcomeMeasure", next_or_prev="next"
-#     )
-#     outcome.delete()
-
-#     if prev_id:
-#         next_url = reverse("outcome-measure-page", args=(evaluation_id, prev_id))
-#     elif next_id:
-#         next_url = reverse("outcome-measure-page", args=(evaluation_id, next_id))
-#     else:
-#         next_url = reverse("outcome-measures", args=(evaluation_id,))
-#     return redirect(next_url)
 
 
 def intro_page_view(request, evaluation_id):


### PR DESCRIPTION
Refactor views for outcome measures so they can be used for other models that have a many to one relationship with evaluations.

To make it more manageable, this should be reviewed after [feature/155-refactor](https://github.com/i-dot-ai/etf/pull/171) has been reviewed/merged in.