### PR TITLE
Feature/fix faker incorrect economic eval type

### DIFF
--- a/etf/evaluation/fakers.py
+++ b/etf/evaluation/fakers.py
@@ -81,7 +81,7 @@ def generate_costs(evaluation):
                 evaluation_id=evaluation.id,
                 description=fake.text(),
                 earliest_spend_date=fake.date(),
-                latest_spend_date=fake.date()
+                latest_spend_date=fake.date(),
             )
         )
     models.EvaluationCost.objects.bulk_create(set_costs)
@@ -139,7 +139,7 @@ def generate_interventions(evaluation):
                 frequency_of_delivery=fake.text(),
                 tailoring=fake.text(),
                 resource_requirements=fake.text(),
-                geographical_information=fake.text()
+                geographical_information=fake.text(),
             )
         )
     models.Intervention.objects.bulk_create(set_interventions)

--- a/etf/evaluation/fakers.py
+++ b/etf/evaluation/fakers.py
@@ -46,7 +46,7 @@ def make_fake_user():
 
 
 def generate_topics():
-    num_topics = random.randint(1, 4)
+    num_topics = random.randint(0, 4)
     set_topics = set()
     for i in range(num_topics):
         set_topics.add(random.choice(choices.Topic.values))
@@ -54,7 +54,7 @@ def generate_topics():
 
 
 def generate_organisations():
-    num_organisations = random.randint(1, 4)
+    num_organisations = random.randint(0, 4)
     set_organisations = set()
     for i in range(num_organisations):
         set_organisations.add(random.choice(enums.Organisation.values))
@@ -62,7 +62,7 @@ def generate_organisations():
 
 
 def generate_evaluation_types():
-    num_types = random.randint(1, 2)
+    num_types = random.randint(0, 2)
     set_types = set()
     for i in range(num_types):
         set_types.add(random.choice(choices.EvaluationTypeOptions.values))
@@ -70,7 +70,7 @@ def generate_evaluation_types():
 
 
 def generate_costs(evaluation):
-    num_costs = random.randint(1, 4)
+    num_costs = random.randint(0, 4)
     set_costs = set()
     for i in range(num_costs):
         set_costs.add(
@@ -87,22 +87,14 @@ def generate_costs(evaluation):
     models.EvaluationCost.objects.bulk_create(set_costs)
 
 
-def generate_document_types():
-    num_types = random.randint(1, 3)
-    set_types = set()
-    for i in range(num_types):
-        set_types.add(random.choice(choices.DocumentType.values))
-    return list(set_types)
-
-
 def generate_documents(evaluation):
-    num_documents = random.randint(1, 4)
+    num_documents = random.randint(0, 4)
     set_documents = set()
     for i in range(num_documents):
         set_documents.add(
             models.Document(
                 description=fake.text(),
-                document_types=generate_document_types(),
+                document_types=random.choices(choices.DocumentType.values),
                 evaluation_id=evaluation.id,
                 document_type_other=fake.text(256),
                 title=fake.text(),
@@ -113,7 +105,7 @@ def generate_documents(evaluation):
 
 
 def generate_dates(evaluation):
-    num_dates = random.randint(1, 4)
+    num_dates = random.randint(0, 4)
     set_dates = set()
     for i in range(num_dates):
         set_dates.add(
@@ -129,7 +121,7 @@ def generate_dates(evaluation):
 
 
 def generate_interventions(evaluation):
-    num_interventions = random.randint(1, 4)
+    num_interventions = random.randint(0, 4)
     set_interventions = set()
     for i in range(num_interventions):
         set_interventions.add(
@@ -154,7 +146,7 @@ def generate_interventions(evaluation):
 
 
 def generate_outcome_measures(evaluation):
-    num_outcome_measures = random.randint(1, 4)
+    num_outcome_measures = random.randint(0, 4)
     set_outcome_measures = set()
     for i in range(num_outcome_measures):
         set_outcome_measures.add(
@@ -176,7 +168,7 @@ def generate_outcome_measures(evaluation):
 
 
 def generate_other_measures(evaluation):
-    num_other_measures = random.randint(1, 4)
+    num_other_measures = random.randint(0, 4)
     set_other_measures = set()
     for i in range(num_other_measures):
         set_other_measures.add(
@@ -193,7 +185,7 @@ def generate_other_measures(evaluation):
 
 
 def generate_processes_and_standards(evaluation):
-    num_processes_and_standards = random.randint(1, 4)
+    num_processes_and_standards = random.randint(0, 4)
     set_processes_and_standards = set()
     for i in range(num_processes_and_standards):
         set_processes_and_standards.add(
@@ -208,7 +200,7 @@ def generate_processes_and_standards(evaluation):
 
 
 def generate_links(evaluation):
-    num_links = random.randint(1, 4)
+    num_links = random.randint(0, 4)
     set_links = set()
     for i in range(num_links):
         set_links.add(

--- a/etf/evaluation/fakers.py
+++ b/etf/evaluation/fakers.py
@@ -46,7 +46,7 @@ def make_fake_user():
 
 
 def generate_topics():
-    num_topics = random.randint(0, 4)
+    num_topics = random.randint(1, 4)
     set_topics = set()
     for i in range(num_topics):
         set_topics.add(random.choice(choices.Topic.values))
@@ -54,7 +54,7 @@ def generate_topics():
 
 
 def generate_organisations():
-    num_organisations = random.randint(0, 4)
+    num_organisations = random.randint(1, 4)
     set_organisations = set()
     for i in range(num_organisations):
         set_organisations.add(random.choice(enums.Organisation.values))
@@ -62,11 +62,163 @@ def generate_organisations():
 
 
 def generate_evaluation_types():
-    num_types = random.randint(0, 2)
+    num_types = random.randint(1, 2)
     set_types = set()
     for i in range(num_types):
         set_types.add(random.choice(choices.EvaluationTypeOptions.values))
     return list(set_types)
+
+
+def generate_costs(evaluation):
+    num_costs = random.randint(1, 4)
+    set_costs = set()
+    for i in range(num_costs):
+        set_costs.add(
+            models.EvaluationCost(
+                item_cost=random.randint(0, 50_000),
+                item_name=fake.text(),
+                created_at=fake.date(),
+                evaluation_id=evaluation.id,
+                description=fake.text(),
+                earliest_spend_date=fake.date(),
+                latest_spend_date=fake.date()
+            )
+        )
+    models.EvaluationCost.objects.bulk_create(set_costs)
+
+
+def generate_document_types():
+    num_types = random.randint(1, 3)
+    set_types = set()
+    for i in range(num_types):
+        set_types.add(random.choice(choices.DocumentType.values))
+    return list(set_types)
+
+
+def generate_documents(evaluation):
+    num_documents = random.randint(1, 4)
+    set_documents = set()
+    for i in range(num_documents):
+        set_documents.add(
+            models.Document(
+                description=fake.text(),
+                document_types=generate_document_types(),
+                evaluation_id=evaluation.id,
+                document_type_other=fake.text(256),
+                title=fake.text(),
+                url=fake.url(),
+            )
+        )
+    models.Document.objects.bulk_create(set_documents)
+
+
+def generate_dates(evaluation):
+    num_dates = random.randint(1, 4)
+    set_dates = set()
+    for i in range(num_dates):
+        set_dates.add(
+            models.EventDate(
+                evaluation_id=evaluation.id,
+                event_date_name=random.choice(choices.EventDateOption.values),
+                date=fake.date(),
+                event_date_type=random.choice(choices.EventDateType.values),
+                reasons_for_change=fake.text(),
+            )
+        )
+    models.EventDate.objects.bulk_create(set_dates)
+
+
+def generate_interventions(evaluation):
+    num_interventions = random.randint(1, 4)
+    set_interventions = set()
+    for i in range(num_interventions):
+        set_interventions.add(
+            models.Intervention(
+                evaluation_id=evaluation.id,
+                fidelity=fake.text(),
+                location=fake.address(),
+                rationale=fake.text(),
+                name=fake.text(1024),
+                brief_description=fake.text(),
+                materials_used=fake.text(),
+                procedures=fake.text(),
+                provider_description=fake.text(),
+                modes_of_delivery=fake.text(),
+                frequency_of_delivery=fake.text(),
+                tailoring=fake.text(),
+                resource_requirements=fake.text(),
+                geographical_information=fake.text()
+            )
+        )
+    models.Intervention.objects.bulk_create(set_interventions)
+
+
+def generate_outcome_measures(evaluation):
+    num_outcome_measures = random.randint(1, 4)
+    set_outcome_measures = set()
+    for i in range(num_outcome_measures):
+        set_outcome_measures.add(
+            models.OutcomeMeasure(
+                evaluation_id=evaluation.id,
+                name=fake.text(256),
+                primary_or_secondary=random.choice(choices.OutcomeType.values),
+                direct_or_surrogate=random.choice(choices.OutcomeMeasure.values),
+                measure_type=random.choice(choices.MeasureType.values),
+                measure_type_other=fake.text(256),
+                description=fake.text(),
+                collection_process=fake.text(),
+                timepoint=fake.text(),
+                minimum_difference=fake.text(),
+                relevance=fake.text(),
+            )
+        )
+    models.OutcomeMeasure.objects.bulk_create(set_outcome_measures)
+
+
+def generate_other_measures(evaluation):
+    num_other_measures = random.randint(1, 4)
+    set_other_measures = set()
+    for i in range(num_other_measures):
+        set_other_measures.add(
+            models.OtherMeasure(
+                evaluation_id=evaluation.id,
+                name=fake.text(256),
+                measure_type=random.choice(choices.MeasureType.values),
+                measure_type_other=fake.text(256),
+                description=fake.text(),
+                collection_process=fake.text(),
+            )
+        )
+    models.OtherMeasure.objects.bulk_create(set_other_measures)
+
+
+def generate_processes_and_standards(evaluation):
+    num_processes_and_standards = random.randint(1, 4)
+    set_processes_and_standards = set()
+    for i in range(num_processes_and_standards):
+        set_processes_and_standards.add(
+            models.ProcessStandard(
+                evaluation_id=evaluation.id,
+                name=fake.text(),
+                conformity=random.choice(choices.FullNoPartial.values),
+                description=fake.text(),
+            )
+        )
+    models.ProcessStandard.objects.bulk_create(set_processes_and_standards)
+
+
+def generate_links(evaluation):
+    num_links = random.randint(1, 4)
+    set_links = set()
+    for i in range(num_links):
+        set_links.add(
+            models.LinkOtherService(
+                evaluation_id=evaluation.id,
+                name_of_service=fake.text(256),
+                link_or_identifier=fake.url(),
+            )
+        )
+    models.LinkOtherService.objects.bulk_create(set_links)
 
 
 def make_evaluation():
@@ -89,6 +241,7 @@ def make_evaluation():
         current_practice=fake.text(),
         issue_relevance=fake.text(),
         evaluation_type=evaluation_type,
+        evaluation_type_other=fake.text(256),
         studied_population=fake.text(),
         eligibility_criteria=fake.text(),
         sample_size=fake.pyint(),
@@ -108,23 +261,34 @@ def make_evaluation():
         confidentiality_and_personal_data=fake.text(),
         breaking_confidentiality=fake.text(),
         other_ethical_information=fake.text(),
-        impact_eval_design_name=fake.words(),
+        impact_eval_design_name=random.choices(choices.ImpactEvalDesign.values),
+        impact_eval_design_name_other=fake.text(256),
         impact_eval_design_justification=fake.text(),
         impact_eval_design_description=fake.text(),
         impact_eval_design_features=fake.text(),
         impact_eval_design_equity=fake.text(),
         impact_eval_design_assumptions=fake.text(),
         impact_eval_design_approach_limitations=fake.text(),
+        impact_eval_framework=random.choice(choices.ImpactFramework.values),
+        impact_eval_framework_other=fake.text(256),
+        impact_eval_basis=random.choice(choices.ImpactAnalysisBasis.values),
+        impact_eval_basis_other=fake.text(256),
         impact_eval_analysis_set=fake.text(),
+        impact_eval_effect_measure_type=random.choice(choices.ImpactMeasureType.values),
         impact_eval_primary_effect_size_measure=fake.text(),
+        impact_eval_effect_measure_interval=random.choice(choices.ImpactMeasureInterval.values),
+        impact_eval_effect_measure_interval_other=fake.text(256),
         impact_eval_primary_effect_size_desc=fake.text(),
+        impact_eval_interpretation_type=random.choice(choices.ImpactEvalInterpretation.values),
+        impact_eval_interpretation_type_other=fake.text(256),
         impact_eval_sensitivity_analysis=fake.text(),
         impact_eval_subgroup_analysis=fake.text(),
         impact_eval_missing_data_handling=fake.text(),
+        impact_eval_fidelity=random.choice(choices.YesNo.values),
         impact_eval_desc_planned_analysis=fake.text(),
         process_eval_methods=fake.text(256),
         process_eval_analysis_description=fake.text(),
-        economic_eval_type=fake.text(256),  # TODO: set this to one of the choices
+        economic_eval_type=random.choice(choices.EconomicEvaluationType.values),
         perspective_costs=fake.text(),
         perspective_benefits=fake.text(),
         monetisation_approaches=fake.text(),
@@ -135,6 +299,7 @@ def make_evaluation():
         other_eval_analysis_description=fake.text(),
         impact_eval_comparison=fake.text(),
         impact_eval_outcome=fake.text(),
+        impact_eval_interpretation=random.choice(choices.ImpactEvalInterpretation.values),
         impact_eval_point_estimate_diff=fake.text(),
         impact_eval_lower_uncertainty=fake.text(),
         impact_eval_upper_uncertainty=fake.text(),
@@ -154,6 +319,14 @@ def add_evals_to_users(user, allow_empty=True):
     for j in range(num_evals):
         eval_data = make_evaluation()
         evaluation = models.Evaluation.objects.create(**eval_data)
+        generate_costs(evaluation)
+        generate_documents(evaluation)
+        generate_dates(evaluation)
+        generate_interventions(evaluation)
+        generate_outcome_measures(evaluation)
+        generate_other_measures(evaluation)
+        generate_processes_and_standards(evaluation)
+        generate_links(evaluation)
         evaluation.users.set([user])
         evaluation.save()
         # TODO - add other models to evaluation

--- a/etf/evaluation/models.py
+++ b/etf/evaluation/models.py
@@ -274,6 +274,9 @@ class Evaluation(TimeStampedModel, UUIDPrimaryKeyBase, NamedModel):
     def get_ethics_committee_approval_display_name(self):
         return choices.YesNo.mapping[self.ethics_committee_approval]
 
+    def get_impact_eval_design_name_display_name(self):
+        return [name[1] for name in choices.ImpactEvalDesign.choices if name[0] in self.impact_eval_design_name]
+
     def __str__(self):
         return f"{self.id} : {self.title}"
 
@@ -587,7 +590,9 @@ class EventDate(TimeStampedModel, UUIDPrimaryKeyBase, NamedModel):
     _name_field = "event_date_name"
 
     def get_event_date_name_display_name(self):
-        return choices.EventDateOption.mapping[self.event_date_name]
+        if self.event_date_name in choices.EventDateOption.values:
+            return choices.EventDateOption.mapping[self.event_date_name]
+        return self.event_date_name
 
     def get_search_text(self):
         event_date_type = [value[1] for value in choices.EventDateType.choices if value[0] == self.event_date_type]

--- a/etf/templates/overview/evaluation-overview-analysis.html
+++ b/etf/templates/overview/evaluation-overview-analysis.html
@@ -7,7 +7,7 @@
 
 
 <div class="back-bar"  >
-  <p class="small mb-0"><a href="#">Back to Search Results</a></p>
+  <p class="small mb-0"><a href="{{url("search")}}">Back to Search Results</a></p>
   <div class="right">
     <form action="#">
       <input type="search" placeholder="Search Evaluation..." class="small" style="width:222px" />

--- a/etf/templates/overview/evaluation-overview-analysis.html
+++ b/etf/templates/overview/evaluation-overview-analysis.html
@@ -73,7 +73,7 @@
             <th>Framework</th>
             <td>
               {% if not data.evaluation.impact_eval_framework %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_impact_eval_framework_display_name()}}
             {% endif %}
@@ -83,7 +83,7 @@
             <th>Analysis basis</th>
             <td>
               {% if not data.evaluation.impact_eval_basis %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_impact_eval_basis_display_name()}}
             {% endif %}
@@ -93,7 +93,7 @@
             <th>Analysis set</th>
             <td>
               {% if not data.evaluation.impact_eval_analysis_set %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_analysis_set}}
             {% endif %}
@@ -103,7 +103,7 @@
             <th>Primary effect size measure type</th>
             <td>
               {% if not data.evaluation.impact_eval_effect_measure_type %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_impact_eval_effect_measure_type_display_name()}}
             {% endif %}
@@ -113,7 +113,7 @@
             <th>Primary effect size measure</th>
             <td>
               {% if not data.evaluation.impact_eval_primary_effect_size_measure %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_primary_effect_size_measure}}
             {% endif %}
@@ -123,7 +123,7 @@
             <th>Primary effect size measure interval</th>
             <td>
               {% if not data.evaluation.impact_eval_effect_measure_interval %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_impact_eval_effect_measure_interval_display_name()}}
             {% endif %}
@@ -133,7 +133,7 @@
             <th>Primary effect size measure description</th>
             <td>
               {% if not data.evaluation.impact_eval_primary_effect_size_desc %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_primary_effect_size_desc}}
             {% endif %}
@@ -143,7 +143,7 @@
             <th>Interpretation type</th>
             <td>
               {% if not data.evaluation.impact_eval_interpretation_type %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_impact_eval_interpretation_type_display_name()}}
             {% endif %}
@@ -153,7 +153,7 @@
             <th>Sensitivity analysis</th>
             <td>
               {% if not data.evaluation.impact_eval_sensitivity_analysis %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_sensitivity_analysis}}
             {% endif %}
@@ -163,7 +163,7 @@
             <th>Subgroup analysis</th>
             <td>
               {% if not data.evaluation.impact_eval_subgroup_analysis %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_subgroup_analysis}}
             {% endif %}
@@ -173,7 +173,7 @@
             <th>Missing data handling</th>
             <td>
               {% if not data.evaluation.impact_eval_missing_data_handling %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_missing_data_handling}}
             {% endif %}
@@ -183,7 +183,7 @@
             <th>Fidelity reporting</th>
             <td>
               {% if not data.evaluation.impact_eval_fidelity %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_impact_eval_fidelity_display_name()}}
             {% endif %}
@@ -193,7 +193,7 @@
             <th>Description of planned analysis</th>
             <td>
               {% if not data.evaluation.impact_eval_desc_planned_analysis %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_desc_planned_analysis}}
             {% endif %}
@@ -209,7 +209,7 @@
             <th>Description of planned analysis</th>
             <td>
               {% if not data.evaluation.process_eval_desc_planned_analysis %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.process_eval_desc_planned_analysis}}
             {% endif %}
@@ -225,7 +225,7 @@
             <th>Description of planned analysis</th>
             <td>
               {% if not data.evaluation.economic_eval_desc_planned_analysis %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.economic_eval_desc_planned_analysis}}
             {% endif %}
@@ -241,7 +241,7 @@
             <th>Description of planned analysis</th>
             <td>
               {% if not data.evaluation.other_eval_desc_planned_analysis %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.other_eval_desc_planned_analysis}}
             {% endif %}
@@ -264,13 +264,13 @@
             <div class="content">
               <table>
                 <tr>
-                  <th>Conformity</th>
-                  <td>{% if processes_and_standard.conformity %}{{processes_and_standard.get_conformity_display_name()}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Description</th>
-                  <td>{% if processes_and_standard.description %}{{processes_and_standard.description}}{% else %}N/A{% endif %}</td>
-                </tr>
+                <th>Conformity</th>
+                <td>{% if processes_and_standard.conformity %}{{processes_and_standard.get_conformity_display_name()}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td>{% if processes_and_standard.description %}{{processes_and_standard.description}}{% else %}Not answered{% endif %}</td>
+              </tr>
               </table>
             </div>
           </div>
@@ -284,7 +284,7 @@
             <th>Ethical committee approval</th>
             <td>
               {% if not data.evaluation.ethics_committee_approval %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_ethics_committee_approval_display_name()}}
             {% endif %}
@@ -294,7 +294,7 @@
             <th>Ethical committee details</th>
             <td>
               {% if not data.evaluation.ethics_committee_details %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.ethics_committee_details}}
             {% endif %}
@@ -304,7 +304,7 @@
             <th>Ethical state of study given existing evidence base</th>
             <td>
               {% if not data.evaluation.ethical_state_given_existing_evidence_base %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.ethical_state_given_existing_evidence_base}}
             {% endif %}
@@ -314,7 +314,7 @@
             <th>Ethical state of study given existing evidence base</th>
             <td>
               {% if not data.evaluation.ethical_state_given_existing_evidence_base %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.ethical_state_given_existing_evidence_base}}
             {% endif %}
@@ -324,7 +324,7 @@
             <th>Risks to participants</th>
             <td>
               {% if not data.evaluation.risks_to_participants %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.risks_to_participants}}
             {% endif %}
@@ -334,7 +334,7 @@
             <th>Risks to study team</th>
             <td>
               {% if not data.evaluation.risks_to_study_team %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.risks_to_study_team}}
             {% endif %}
@@ -344,7 +344,7 @@
             <th>Participant involvement</th>
             <td>
               {% if not data.evaluation.participant_involvement %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.participant_involvement}}
             {% endif %}
@@ -354,7 +354,7 @@
             <th>Participant consent</th>
             <td>
               {% if not data.evaluation.participant_consent %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.participant_consent}}
             {% endif %}
@@ -364,7 +364,7 @@
             <th>Participant information</th>
             <td>
               {% if not data.evaluation.participant_information %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.participant_information}}
             {% endif %}
@@ -374,7 +374,7 @@
             <th>Participant payment</th>
             <td>
               {% if not data.evaluation.participant_payment %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.participant_payment}}
             {% endif %}
@@ -384,7 +384,7 @@
             <th>Confidentiality and personal data</th>
             <td>
               {% if not data.evaluation.confidentiality_and_personal_data %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.confidentiality_and_personal_data}}
             {% endif %}
@@ -394,7 +394,7 @@
             <th>Breaking confidentiality</th>
             <td>
               {% if not data.evaluation.breaking_confidentiality %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.breaking_confidentiality}}
             {% endif %}
@@ -404,7 +404,7 @@
             <th>Other ethical information</th>
             <td>
               {% if not data.evaluation.other_ethical_information %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.other_ethical_information}}
             {% endif %}

--- a/etf/templates/overview/evaluation-overview-costs.html
+++ b/etf/templates/overview/evaluation-overview-costs.html
@@ -7,7 +7,7 @@
 
 
 <div class="back-bar"  >
-  <p class="small mb-0"><a href="#">Back to Search Results</a></p>
+  <p class="small mb-0"><a href="{{url("search")}}">Back to Search Results</a></p>
   <div class="right">
     <form action="#">
       <input type="search" placeholder="Search Evaluation..." class="small" style="width:222px" />

--- a/etf/templates/overview/evaluation-overview-costs.html
+++ b/etf/templates/overview/evaluation-overview-costs.html
@@ -84,19 +84,19 @@
             <table>
               <tr>
                 <th>Description</th>
-                <td>{% if cost.description %}{{cost.description}}{% else %}N/A{% endif %}</td>
+                <td>{% if cost.description %}{{cost.description}}{% else %}Not answered{% endif %}</td>
               </tr>
               <tr>
                 <th>Item cost (£)</th>
-                <td>{% if cost.item_cost %}{{cost.item_cost}}{% else %}N/A{% endif %}</td>
+                <td>{% if cost.item_cost %}{{cost.item_cost}}{% else %}Not answered{% endif %}</td>
               </tr>
               <tr>
                 <th>Earliest spend date</th>
-                <td>{% if cost.earliest_spend_date %}{{cost.earliest_spend_date.strftime('%d %b %Y')}}{% else %}N/A{% endif %}</td>
+                <td>{% if cost.earliest_spend_date %}{{cost.earliest_spend_date.strftime('%d %b %Y')}}{% else %}Not answered{% endif %}</td>
               </tr>
               <tr>
                 <th>Latest spend date</th>
-                <td>{% if cost.latest_spend_date %}{{cost.latest_spend_date.strftime('%d %b %Y')}}{% else %}N/A{% endif %}</td>
+                <td>{% if cost.latest_spend_date %}{{cost.latest_spend_date.strftime('%d %b %Y')}}{% else %}Not answered{% endif %}</td>
               </tr>
             </table>
           </div>

--- a/etf/templates/overview/evaluation-overview-design.html
+++ b/etf/templates/overview/evaluation-overview-design.html
@@ -7,7 +7,7 @@
 
 
 <div class="back-bar"  >
-  <p class="small mb-0"><a href="#">Back to Search Results</a></p>
+  <p class="small mb-0"><a href="{{url("search")}}">Back to Search Results</a></p>
   <div class="right">
     <form action="#">
       <input type="search" placeholder="Search Evaluation..." class="small" style="width:222px" />

--- a/etf/templates/overview/evaluation-overview-design.html
+++ b/etf/templates/overview/evaluation-overview-design.html
@@ -64,10 +64,11 @@
           <tr>
             <th>Design name</th>
           {% if not data.evaluation.impact_eval_design_name %}
-            <td>N/A</td>
+            <td>Not answered</td>
           {% else %}
             <td>
-            {% for design_name in data.evaluation.impact_eval_design_name %}
+            {% set design_names = data.evaluation.get_impact_eval_design_name_display_name() %}
+            {% for design_name in design_names %}
               <p>{{design_name}}</p>
             {% endfor %}
             </td>
@@ -77,7 +78,7 @@
             <th>Justification for design</th>
             <td>
               {% if not data.evaluation.impact_eval_design_justification %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_design_justification}}
             {% endif %}
@@ -87,7 +88,7 @@
             <th>Description of planned design</th>
             <td>
               {% if not data.evaluation.impact_eval_design_description %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_design_description}}
             {% endif %}
@@ -97,7 +98,7 @@
             <th>Features to reflect real-world implementation</th>
             <td>
               {% if not data.evaluation.impact_eval_design_features %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_design_features}}
             {% endif %}
@@ -107,7 +108,7 @@
             <th>Equity</th>
             <td>
               {% if not data.evaluation.impact_eval_design_equity %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_design_equity}}
             {% endif %}
@@ -117,7 +118,7 @@
             <th>Assumptions</th>
             <td>
               {% if not data.evaluation.impact_eval_design_assumptions %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_design_assumptions}}
             {% endif %}
@@ -127,7 +128,7 @@
             <th>Limitations of approach</th>
             <td>
               {% if not data.evaluation.impact_eval_design_approach_limitations %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_design_approach_limitations}}
             {% endif %}
@@ -156,7 +157,7 @@
             <th>Economic evaluation</th>
             <td>
               {% if not data.evaluation.economic_eval_type %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_economic_eval_type_display_name()}}
             {% endif %}
@@ -166,7 +167,7 @@
             <th>Perspective: costs</th>
             <td>
               {% if not data.evaluation.perspective_costs %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.perspective_costs}}
             {% endif %}
@@ -176,7 +177,7 @@
             <th>Perspective: benefits</th>
             <td>
               {% if not data.evaluation.perspective_benefits %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.perspective_benefits}}
             {% endif %}
@@ -186,7 +187,7 @@
             <th>Monetisation approach(es)</th>
             <td>
               {% if not data.evaluation.monetisation_approaches %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.monetisation_approaches}}
             {% endif %}
@@ -196,7 +197,7 @@
             <th>Design details</th>
             <td>
               {% if not data.evaluation.economic_eval_design_details %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.economic_eval_design_details}}
             {% endif %}
@@ -212,7 +213,7 @@
             <th>Design type</th>
             <td>
               {% if not data.evaluation.other_eval_design_type %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.other_eval_design_type}}
             {% endif %}
@@ -222,7 +223,7 @@
             <th>Design details</th>
             <td>
               {% if not data.evaluation.other_eval_design_details %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.other_eval_design_details}}
             {% endif %}
@@ -238,7 +239,7 @@
             <th>Studied population including location</th>
             <td>
               {% if not data.evaluation.studied_population %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.studied_population}}
             {% endif %}
@@ -248,7 +249,7 @@
             <th>Eligibility criteria</th>
             <td>
               {% if not data.evaluation.eligibility_criteria %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.eligibility_criteria}}
             {% endif %}
@@ -258,7 +259,7 @@
             <th>Sample size</th>
             <td>
               {% if not data.evaluation.sample_size %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.sample_size}}
             {% endif %}
@@ -268,7 +269,7 @@
             <th>Sample size units</th>
             <td>
               {% if not data.evaluation.sample_size_units %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.sample_size_units}}
             {% endif %}
@@ -278,7 +279,7 @@
             <th>Sample size details</th>
             <td>
               {% if not data.evaluation.sample_size_details %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.sample_size_details}}
             {% endif %}
@@ -294,7 +295,7 @@
             <th>Process for recruitment</th>
             <td>
               {% if not data.evaluation.process_for_recruitment %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.process_for_recruitment}}
             {% endif %}
@@ -304,7 +305,7 @@
             <th>Recruitment schedule including date of first recruitment</th>
             <td>
               {% if not data.evaluation.recruitment_schedule %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.recruitment_schedule}}
             {% endif %}

--- a/etf/templates/overview/evaluation-overview-findings.html
+++ b/etf/templates/overview/evaluation-overview-findings.html
@@ -7,7 +7,7 @@
 
 
 <div class="back-bar"  >
-  <p class="small mb-0"><a href="#">Back to Search Results</a></p>
+  <p class="small mb-0"><a href="{{url("search")}}">Back to Search Results</a></p>
   <div class="right">
     <form action="#">
       <input type="search" placeholder="Search Evaluation..." class="small" style="width:222px" />

--- a/etf/templates/overview/evaluation-overview-findings.html
+++ b/etf/templates/overview/evaluation-overview-findings.html
@@ -63,7 +63,7 @@
             <th>Comparison</th>
             <td>
               {% if not data.evaluation.impact_eval_comparison %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_comparison}}
             {% endif %}
@@ -73,7 +73,7 @@
             <th>Outcome</th>
             <td>
               {% if not data.evaluation.impact_eval_outcome %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_outcome}}
             {% endif %}
@@ -83,7 +83,7 @@
             <th>Interpretation</th>
             <td>
               {% if not data.evaluation.impact_eval_interpretation %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.get_impact_eval_interpretation_display_name()}}
             {% endif %}
@@ -93,7 +93,7 @@
             <th>Point estimate of difference</th>
             <td>
               {% if not data.evaluation.impact_eval_point_estimate_diff %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_point_estimate_diff}}
             {% endif %}
@@ -103,7 +103,7 @@
             <th>Lower uncertainty bound</th>
             <td>
               {% if not data.evaluation.impact_eval_lower_uncertainty %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_lower_uncertainty}}
             {% endif %}
@@ -113,7 +113,7 @@
             <th>Upper uncertainty bound</th>
             <td>
               {% if not data.evaluation.impact_eval_upper_uncertainty %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.impact_eval_upper_uncertainty}}
             {% endif %}
@@ -129,7 +129,7 @@
             <th>Summary findings</th>
             <td>
               {% if not data.evaluation.process_eval_summary_findings %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.process_eval_summary_findings}}
             {% endif %}
@@ -139,7 +139,7 @@
             <th>Findings</th>
             <td>
               {% if not data.evaluation.process_eval_findings %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.process_eval_findings}}
             {% endif %}
@@ -155,7 +155,7 @@
             <th>Summary findings</th>
             <td>
               {% if not data.evaluation.economic_eval_summary_findings %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.economic_eval_summary_findings}}
             {% endif %}
@@ -165,7 +165,7 @@
             <th>Findings</th>
             <td>
               {% if not data.evaluation.economic_eval_findings %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.economic_eval_findings}}
             {% endif %}
@@ -181,7 +181,7 @@
             <th>Summary findings</th>
             <td>
               {% if not data.evaluation.other_eval_summary_findings %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.other_eval_summary_findings}}
             {% endif %}
@@ -191,7 +191,7 @@
             <th>Findings</th>
             <td>
               {% if not data.evaluation.other_eval_findings %}
-              N/A
+              Not answered
             {% else %}
               {{data.evaluation.other_eval_findings}}
             {% endif %}

--- a/etf/templates/overview/evaluation-overview-measured.html
+++ b/etf/templates/overview/evaluation-overview-measured.html
@@ -7,7 +7,7 @@
 
 
 <div class="back-bar"  >
-  <p class="small mb-0"><a href="#">Back to Search Results</a></p>
+  <p class="small mb-0"><a href="{{url("search")}}">Back to Search Results</a></p>
   <div class="right">
     <form action="#">
       <input type="search" placeholder="Search Evaluation..." class="small" style="width:222px" />

--- a/etf/templates/overview/evaluation-overview-measured.html
+++ b/etf/templates/overview/evaluation-overview-measured.html
@@ -101,53 +101,53 @@
             <div class="content">
               <table>
                 <tr>
-                  <th>Description</th>
-                  <td>{% if intervention.brief_description %}{{intervention.brief_description}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Rationale</th>
-                  <td>{% if intervention.rationale %}{{intervention.rationale}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Materials used</th>
-                  <td>{% if intervention.materials_used %}{{intervention.materials_used}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Procedures</th>
-                  <td>{% if intervention.procedures %}{{intervention.procedures}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Provider description</th>
-                  <td>{% if intervention.provider_description %}{{intervention.provider_description}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Modes of delivery</th>
-                  <td>{% if intervention.modes_of_delivery %}{{intervention.modes_of_delivery}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Location</th>
-                  <td>{% if intervention.location %}{{intervention.location}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Frequency of delivery</th>
-                  <td>{% if intervention.frequency_of_delivery %}{{intervention.frequency_of_delivery}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Tailoring</th>
-                  <td>{% if intervention.tailoring %}{{intervention.tailoring}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Fidelity</th>
-                  <td>{% if intervention.fidelity %}{{intervention.fidelity}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Resource requirements</th>
-                  <td>{% if intervention.resource_requirements %}{{intervention.resource_requirements}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Geographical information</th>
-                  <td>{% if intervention.geographical_information %}{{intervention.geographical_information}}{% else %}N/A{% endif %}</td>
-                </tr>
+                <th>Description</th>
+                <td>{% if intervention.brief_description %}{{intervention.brief_description}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Rationale</th>
+                <td>{% if intervention.rationale %}{{intervention.rationale}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Materials used</th>
+                <td>{% if intervention.materials_used %}{{intervention.materials_used}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Procedures</th>
+                <td>{% if intervention.procedures %}{{intervention.procedures}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Provider description</th>
+                <td>{% if intervention.provider_description %}{{intervention.provider_description}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Modes of delivery</th>
+                <td>{% if intervention.modes_of_delivery %}{{intervention.modes_of_delivery}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Location</th>
+                <td>{% if intervention.location %}{{intervention.location}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Frequency of delivery</th>
+                <td>{% if intervention.frequency_of_delivery %}{{intervention.frequency_of_delivery}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Tailoring</th>
+                <td>{% if intervention.tailoring %}{{intervention.tailoring}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Fidelity</th>
+                <td>{% if intervention.fidelity %}{{intervention.fidelity}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Resource requirements</th>
+                <td>{% if intervention.resource_requirements %}{{intervention.resource_requirements}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Geographical information</th>
+                <td>{% if intervention.geographical_information %}{{intervention.geographical_information}}{% else %}Not answered{% endif %}</td>
+              </tr>
               </table>
             </div>
           </div>
@@ -168,41 +168,41 @@
             <div class="content">
               <table>
                 <tr>
-                  <th>Primary or secondary</th>
-                  <td>{% if outcome_measure.primary_or_secondary %}{{outcome_measure.get_primary_or_secondary_display_name()}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Direct or surrogate</th>
-                  <td>{% if outcome_measure.direct_or_surrogate %}{{outcome_measure.get_direct_or_surrogate_display_name()}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Measure type</th>
-                  <td>{% if outcome_measure.measure_type %}{{outcome_measure.get_measure_type_display_name()}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Measure type (other)</th>
-                  <td>{% if outcome_measure.measure_type_other %}{{outcome_measure.measure_type_other}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Description</th>
-                  <td>{% if outcome_measure.description %}{{outcome_measure.description}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Collection process</th>
-                  <td>{% if outcome_measure.collection_process %}{{outcome_measure.collection_process}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Timepoint(s) of interest</th>
-                  <td>{% if outcome_measure.timepoint %}{{outcome_measure.timepoint}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Minimum practically important difference</th>
-                  <td>{% if outcome_measure.minimum_difference %}{{outcome_measure.minimum_difference}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Relevance of outcome</th>
-                  <td>{% if outcome_measure.relevance %}{{outcome_measure.relevance}}{% else %}N/A{% endif %}</td>
-                </tr>
+                <th>Primary or secondary</th>
+                <td>{% if outcome_measure.primary_or_secondary %}{{outcome_measure.get_primary_or_secondary_display_name()}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Direct or surrogate</th>
+                <td>{% if outcome_measure.direct_or_surrogate %}{{outcome_measure.get_direct_or_surrogate_display_name()}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Measure type</th>
+                <td>{% if outcome_measure.measure_type %}{{outcome_measure.get_measure_type_display_name()}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Measure type (other)</th>
+                <td>{% if outcome_measure.measure_type_other %}{{outcome_measure.measure_type_other}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td>{% if outcome_measure.description %}{{outcome_measure.description}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Collection process</th>
+                <td>{% if outcome_measure.collection_process %}{{outcome_measure.collection_process}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Timepoint(s) of interest</th>
+                <td>{% if outcome_measure.timepoint %}{{outcome_measure.timepoint}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Minimum practically important difference</th>
+                <td>{% if outcome_measure.minimum_difference %}{{outcome_measure.minimum_difference}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Relevance of outcome</th>
+                <td>{% if outcome_measure.relevance %}{{outcome_measure.relevance}}{% else %}Not answered{% endif %}</td>
+              </tr>
               </table>
             </div>
           </div>
@@ -223,21 +223,21 @@
             <div class="content">
               <table>
                 <tr>
-                  <th>Measure type</th>
-                  <td>{% if other_measure.measure_type %}{{other_measure.get_measure_type_display_name()}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Measure type (other)</th>
-                  <td>{% if other_measure.measure_type_other %}{{other_measure.measure_type_other}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Description</th>
-                  <td>{% if other_measure.description %}{{other_measure.description}}{% else %}N/A{% endif %}</td>
-                </tr>
-                <tr>
-                  <th>Collection process</th>
-                  <td>{% if other_measure.collection_process %}{{other_measure.collection_process}}{% else %}N/A{% endif %}</td>
-                </tr>
+                <th>Measure type</th>
+                <td>{% if other_measure.measure_type %}{{other_measure.get_measure_type_display_name()}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Measure type (other)</th>
+                <td>{% if other_measure.measure_type_other %}{{other_measure.measure_type_other}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Description</th>
+                <td>{% if other_measure.description %}{{other_measure.description}}{% else %}Not answered{% endif %}</td>
+              </tr>
+              <tr>
+                <th>Collection process</th>
+                <td>{% if other_measure.collection_process %}{{other_measure.collection_process}}{% else %}Not answered{% endif %}</td>
+              </tr>
               </table>
             </div>
           </div>

--- a/etf/templates/overview/evaluation-overview.html
+++ b/etf/templates/overview/evaluation-overview.html
@@ -7,7 +7,7 @@
 
 
 <div class="back-bar"  >
-  <p class="small mb-0"><a href="#">Back to Search Results</a></p>
+  <p class="small mb-0"><a href="{{url("search")}}">Back to Search Results</a></p>
   <div class="right">
     <form action="#">
       <input type="search" placeholder="Search Evaluation..." class="small" style="width:222px" />

--- a/etf/templates/overview/evaluation-overview.html
+++ b/etf/templates/overview/evaluation-overview.html
@@ -64,25 +64,37 @@
           <tr>
             <th>Topic/s</th>
             <td>
-              {% for topic in data.topics %}
-              <div class="chip green">{{topic}}</div>
-              {% endfor %}
+              {% if data.topics | length > 0 %}
+                {% for topic in data.topics %}
+                  <div class="chip green">{{topic}}</div>
+                {% endfor %}
+              {% else %}
+                <p>No topics found</p>
+              {% endif %}
             </td>
           </tr>
           <tr>
             <th>Organisation(s)</th>
             <td>
-              {% for organisation in data.organisations %}
-              <div class="chip orange">{{organisation}}</div>
-              {% endfor %}
+              {% if data.organisations | length > 0 %}
+                {% for organisation in data.organisations %}
+                  <div class="chip orange">{{organisation}}</div>
+                {% endfor %}
+              {% else %}
+                <p>No organisations found</p>
+              {% endif %}
               </td>
           </tr>
           <tr>
             <th>Evaluation types</th>
             <td>
-            {% for evaluation_type in data.evaluation_types %}
-              <p>{{evaluation_type}}</p>
-            {% endfor %}
+            {% if data.evaluation_types | length > 0 %}
+              {% for evaluation_type in data.evaluation_types %}
+                <p>{{evaluation_type}}</p>
+              {% endfor %}
+            {% else %}
+              <p>No evaluation types found</p>
+            {% endif %}
           </td>
           </tr>
         </table>
@@ -138,19 +150,19 @@
         <table>
           <tr>
             <th>Why would improvements in relation to this issue matter?</th>
-            <td>{% if data.evaluation.why_improvements_matter %}{{data.evaluation.why_improvements_matter}}{% else %}N/A{% endif %}</td>
+            <td>{% if data.evaluation.why_improvements_matter %}{{data.evaluation.why_improvements_matter}}{% else %}Not answered{% endif %}</td>
           </tr>
           <tr>
             <th>Who does it matter to?</th>
-            <td>{% if data.evaluation.who_improvements_matter_to %}{{data.evaluation.who_improvements_matter_to}}{% else %}N/A{% endif %}</td>
+            <td>{% if data.evaluation.who_improvements_matter_to %}{{data.evaluation.who_improvements_matter_to}}{% else %}Not answered{% endif %}</td>
           </tr>
           <tr>
             <th>Current practice</th>
-            <td>{% if data.evaluation.current_practice %}{{data.evaluation.current_practice}}{% else %}N/A{% endif %}</td>
+            <td>{% if data.evaluation.current_practice %}{{data.evaluation.current_practice}}{% else %}Not answered{% endif %}</td>
           </tr>
           <tr>
             <th>Relevance of the study</th>
-            <td>{% if data.evaluation.issue_relevance %}{{data.evaluation.issue_relevance}}{% else %}N/A{% endif %}</td>
+            <td>{% if data.evaluation.issue_relevance %}{{data.evaluation.issue_relevance}}{% else %}Not answered{% endif %}</td>
           </tr>
         </table>
       </div>

--- a/etf/templates/overview/evaluation-overview.html
+++ b/etf/templates/overview/evaluation-overview.html
@@ -116,7 +116,7 @@
           <tr>
             <th>Event Date</th>
             <td>
-              <div class="badge">{{date.date.strftime('%b %Y')}}</div>
+              <div class="badge">{% if date.date %}{{date.date.strftime('%b %Y')}}{% else %}No date provided{% endif %}</div>
             </td>
           </tr>
         </table>

--- a/etf/templates/search-form.html
+++ b/etf/templates/search-form.html
@@ -208,6 +208,10 @@
                 <td>{{evaluation.get_list_organisations_display_names()|join(', ')}}</td>
               </tr>
               <tr>
+                <th>Topic(s)</th>
+                <td>{{evaluation.get_list_topics_display_names()|join(', ')}}</td>
+              </tr>
+              <tr>
                 <th>Evaluation type</th>
                 <td>{{evaluation.get_list_evaluation_types_display_names()|join(', ')}}</td>
               </tr>


### PR DESCRIPTION
- Updated fakers with all values from schema (except search_text and rsm_import_id)
- Added multiple-object creation to faker to generate interventions, outcome_measures etc.
- Changed N/A to not answered
- Added util functions to models where applicable for human readable str
- Added some more checks for empty values in evaluations for summary pages
- Added logic to "back to search results" button
- Added topics to evaluation summary in search results