### PR TITLE
remove xansium email domain

### DIFF
--- a/etf/settings.py
+++ b/etf/settings.py
@@ -180,11 +180,7 @@ LOGIN_REDIRECT_URL = "index"
 
 ALLOW_EXAMPLE_EMAILS = env.bool("ALLOW_EXAMPLE_EMAILS", default=True)
 
-DEFAULT_ALLOWED_DOMAINS = frozenset(
-    [
-        "xansium.com",  # Required for user research - to be removed later
-    ]
-)
+DEFAULT_ALLOWED_DOMAINS = frozenset([])  # TODO - more to be added
 
 if ALLOW_EXAMPLE_EMAILS:
     ALLOWED_DOMAINS = DEFAULT_ALLOWED_DOMAINS.union({"example.com"})


### PR DESCRIPTION
Fixes #255 (was only in for user testing).

Will add email domains for Civil Service when we get them (I am chasing with another team).

Probably need to think how this fits in with externals who are invited to the registry.
