### PR TITLE
Feature/allowed domains

### DIFF
--- a/etf/allowed_domains.py
+++ b/etf/allowed_domains.py
@@ -30,47 +30,48 @@ CABINET_OFFICE = frozenset(
         "odandd.gov.uk",
     ]
 )
-DEPT_FOR_BUSINESS_AND_TRADE = frozenset([])
-DEPT_FOR_CULTURE_MEDIA_SPORT = frozenset([])
-DEPT_FOR_EDUCATION = frozenset([])
-DEPT_FOR_ENERGY_SECURITY_NET_ZERO = frozenset([])
-DEFRA = frozenset([])
-DLUHC = frozenset([])
-DEPT_SCIENCE_INNOVATION_TECHNOLOGY = frozenset([])
-DEPT_TRANSPORT = frozenset([])
-DEPT_WORK_PENSIONS = frozenset([])
-DEPT_HEALTH_SOCIAL_CARE = frozenset([])
-FOREIGN_OFFICE = frozenset([])
-HMT = frozenset([])
-HOME_OFFICE = frozenset([])
-MINISTRY_OF_DEFENCE = frozenset([])
-MINISTRY_OF_JUSTICE = frozenset([])
+DEPT_FOR_BUSINESS_AND_TRADE = frozenset(["beis.gov.uk", "trade.gov.uk", "companieshouse.gov.uk"])
+DEPT_FOR_CULTURE_MEDIA_SPORT = frozenset(["dcms.gov.uk"])
+DEPT_FOR_EDUCATION = frozenset(["education.gov.uk"])
+DEPT_FOR_ENERGY_SECURITY_NET_ZERO = frozenset(["beis.gov.uk"])
+DEFRA = frozenset(["defra.gov.uk"])
+DLUHC = frozenset(["levellingup.gov.uk"])
+DEPT_SCIENCE_INNOVATION_TECHNOLOGY = frozenset(["beis.gov.uk"])
+DEPT_TRANSPORT = frozenset(["dft.gov.uk"])
+DEPT_WORK_PENSIONS = frozenset(["dwp.gov.uk"])
+DEPT_HEALTH_SOCIAL_CARE = frozenset(["dhsc.gov.uk"])
+FOREIGN_OFFICE = frozenset(["fcdo.gov.uk"])
+HMT = frozenset(["hmtreasury.gov.uk"])
+HOME_OFFICE = frozenset(["homeoffice.gov.uk"])
+MINISTRY_OF_DEFENCE = frozenset(["mod.gov.uk", "dstl.gov.uk"])
+MINISTRY_OF_JUSTICE = frozenset(["justice.gov.uk", "digital.justice.gov.uk"])
 NI_OFFICE = frozenset([])
 OFFICE_OF_ADVOCATE_GENERAL_FOR_SCOTLAND = frozenset([])
 OFFICE_OF_LEADER_OF_HOUSE_OF_COMMONS = frozenset([])
 OFFICE_OF_LEADER_HOUSE_OF_LORDS = frozenset([])
 OFFICE_OF_SOS_SCOTLAND = frozenset([])
 OFFICE_OF_SOS_WALES = frozenset([])
-UK_EXPORT_FINANCE = frozenset([])
+UK_EXPORT_FINANCE = frozenset(["ukexportfinance.gov.uk"])
+
 
 # Non-ministerial departments
 
 CHARITY_COMMISSION = frozenset([])
-COMPETITION_MARKETS_AUTHORITY = frozenset([])
+COMPETITION_MARKETS_AUTHORITY = frozenset(["cma.gov.uk"])
 CROWN_PROSECUTION_SERVICE = frozenset([])
 FOOD_STANDARDS_AGENCY = frozenset([])
 FORESTRY_COMMISSION = frozenset([])
 GOV_ACTUARY_DEPT = frozenset([])
 GOV_LEGAL_DEPT = frozenset([])
 HM_LAND_REGISTRY = frozenset([])
-HMRC = frozenset([])
+HMRC = frozenset(["hmrc.gov.uk"])
 NS_AND_I = frozenset([])
 NATIONAL_ARCHIVES = frozenset([])
-NATIONAL_CRIME_AGENCY = frozenset([])
+NATIONAL_CRIME_AGENCY = frozenset(["nca.gov.uk"])
 OFFICE_OF_RAIL_AND_ROAD = frozenset([])
 OFGEM = frozenset([])
 OFQUAL = frozenset([])
-OFSTED = frozenset([])
+OFSTED = frozenset(["ofsted.gov.uk"])
 SERIOUS_FRAUD_OFFICE = frozenset([])
 SUPREME_COURT_UK = frozenset([])
 UK_STATISTICS_AUTHORITY = frozenset([])
@@ -78,9 +79,14 @@ WATER_SERVICES_REGULATION_AUTHORITY = frozenset([])
 
 # Devolved administrations
 
-SCOTTISH_GOVERNMENT = frozenset([])
+SCOTTISH_GOVERNMENT = frozenset(["gov.scot"])
 WELSH_GOVERNMENT = frozenset([])
 NI_GOVERNMENT = frozenset([])  # Note, this is not part of UK Civil Service
+
+# Other emails
+# Things like profession emails, Fast Stream emails etc
+
+OTHER = frozenset(["faststream.civilservice.gov.uk"])
 
 
 # All domains
@@ -132,4 +138,5 @@ CIVIL_SERVICE_DOMAINS = frozenset.union(
     SCOTTISH_GOVERNMENT,
     WELSH_GOVERNMENT,
     NI_GOVERNMENT,
+    OTHER,
 )

--- a/etf/allowed_domains.py
+++ b/etf/allowed_domains.py
@@ -1,0 +1,92 @@
+"""
+Add known domains for government departments: https://www.gov.uk/government/organisations.
+
+This is a list of CIVIL SERVICE domains not PUBLIC SERVICE eg NHS is public body but not civil service.
+Arms' Length Bodies can be either - so check before adding.
+
+Domains for ALBs are listed under the corresponding department.
+
+To note - BEIS is also listed.
+"""
+
+# Ministerial departments
+
+ATTORNEY_GENERALS_OFFICE = []
+
+CABINET_OFFICE = []
+
+DEPARTMENT_FOR_BUSINESS_AND_TRADE = []
+
+DEPARMENT_FOR_CULTURE_MEDIA_SPORT = []
+
+DEPARMENT_FOR_EDUCATION = []
+
+DEPARTMENT_FOR_ENERGY_SECURITY_NET_ZERO = []
+
+DEFRA = []
+
+DLUHC = []
+
+DEPT_SCIENCE_INNOVATION_TECHNOLOGY = []
+
+DEPT_TRANSPORT = []
+
+DEPT_WORK_PENSIONS = []
+
+DEPT_HEALTH_SOCIAL_CARE = []
+
+FOREIGN_OFFICE = []
+
+HM_TREASURY = []
+
+HOME_OFFICE = []
+
+MINISTRY_OF_DEFENCE = []
+
+MINISTRY_OF_JUSTICE = []
+
+NI_OFFICE = []
+
+OFFICE_OF_ADVOCAATE_GENERAL_FOR_SCOTLAND = []
+
+OFFICE_OF_LEADER_OF_HOUSE_OF_COMMONS = []
+
+OFFICE_OF_LEADER_HOUSE_OF_LORDS = []
+
+OFFICE_OF_SOS_SCOTLAND = []
+
+OFFICE_OF_SOS_WALES = []
+
+UK_EXPORT_FINANCE = []
+
+
+# Non-ministerial departments
+
+CHARITY_COMMISSION = []
+
+COMPETITION_MARKETS_AUTHORITY = []
+CROWN_PROSECUTION_SERVICE = []
+FOOD_STANDARDS_AGENCY = []
+FORESTRY_COMMISSION = []
+
+GOV_ACTUARY_DEPT = []
+GOV_LEGAL_DEPT = []
+HM_LAND_REGISTRY = []
+HMRC = []
+NS_AND_I = []
+NATIONAL_ARCHIVES = []
+NATIONAL_CRIME_AGENCY = []
+OFFICE_OF_RAIL_AND_ROAD = []
+OFGEM = []
+OFQUAL = []
+OFSTED = []
+SERIOUS_FRAUD_OFFICE = []
+SUPREME_COURT_UK = []
+UK_STATISTICS_AUTHORITY = []
+WATER_SERVICES_REGULATION_AUTHORITY = []
+
+# Devolved administrations
+
+SCOTTISH_GOVERNMENT = []
+WELSH_GOVERNMENT = []
+NI_GOVERNMENT = []  # Note, this is

--- a/etf/allowed_domains.py
+++ b/etf/allowed_domains.py
@@ -1,92 +1,135 @@
 """
 Add known domains for government departments: https://www.gov.uk/government/organisations.
 
-This is a list of CIVIL SERVICE domains not PUBLIC SERVICE eg NHS is public body but not civil service.
-Arms' Length Bodies can be either - so check before adding.
+This is a list of CIVIL SERVICE domains not PUBLIC SERVICE
+eg NHS is public body but not Civil Service.
 
+Arms' Length Bodies can be either - so check before adding.
 Domains for ALBs are listed under the corresponding department.
 
-To note - BEIS is also listed.
+To consider - what do we do when departments change, do we keep the old domains?
+
 """
 
 # Ministerial departments
 
-ATTORNEY_GENERALS_OFFICE = []
-
-CABINET_OFFICE = []
-
-DEPARTMENT_FOR_BUSINESS_AND_TRADE = []
-
-DEPARMENT_FOR_CULTURE_MEDIA_SPORT = []
-
-DEPARMENT_FOR_EDUCATION = []
-
-DEPARTMENT_FOR_ENERGY_SECURITY_NET_ZERO = []
-
-DEFRA = []
-
-DLUHC = []
-
-DEPT_SCIENCE_INNOVATION_TECHNOLOGY = []
-
-DEPT_TRANSPORT = []
-
-DEPT_WORK_PENSIONS = []
-
-DEPT_HEALTH_SOCIAL_CARE = []
-
-FOREIGN_OFFICE = []
-
-HM_TREASURY = []
-
-HOME_OFFICE = []
-
-MINISTRY_OF_DEFENCE = []
-
-MINISTRY_OF_JUSTICE = []
-
-NI_OFFICE = []
-
-OFFICE_OF_ADVOCAATE_GENERAL_FOR_SCOTLAND = []
-
-OFFICE_OF_LEADER_OF_HOUSE_OF_COMMONS = []
-
-OFFICE_OF_LEADER_HOUSE_OF_LORDS = []
-
-OFFICE_OF_SOS_SCOTLAND = []
-
-OFFICE_OF_SOS_WALES = []
-
-UK_EXPORT_FINANCE = []
-
+ATTORNEY_GENERALS_OFFICE = frozenset([])
+CABINET_OFFICE = frozenset(
+    [
+        "cabinet-office.x.gsi.gov.uk",
+        "cabinetoffice.gov.uk",
+        "crowncommercial.gov.uk",
+        "csep.gov.uk",
+        "cslearning.gov.uk",
+        "csc.gov.uk",
+        "digital.cabinet-office.gov.uk",
+        "geo.gov.uk",
+        "gpa.gov.uk",
+        "ipa.gov.uk",
+        "no10.gov.uk",
+        "odandd.gov.uk",
+    ]
+)
+DEPT_FOR_BUSINESS_AND_TRADE = frozenset([])
+DEPT_FOR_CULTURE_MEDIA_SPORT = frozenset([])
+DEPT_FOR_EDUCATION = frozenset([])
+DEPT_FOR_ENERGY_SECURITY_NET_ZERO = frozenset([])
+DEFRA = frozenset([])
+DLUHC = frozenset([])
+DEPT_SCIENCE_INNOVATION_TECHNOLOGY = frozenset([])
+DEPT_TRANSPORT = frozenset([])
+DEPT_WORK_PENSIONS = frozenset([])
+DEPT_HEALTH_SOCIAL_CARE = frozenset([])
+FOREIGN_OFFICE = frozenset([])
+HMT = frozenset([])
+HOME_OFFICE = frozenset([])
+MINISTRY_OF_DEFENCE = frozenset([])
+MINISTRY_OF_JUSTICE = frozenset([])
+NI_OFFICE = frozenset([])
+OFFICE_OF_ADVOCATE_GENERAL_FOR_SCOTLAND = frozenset([])
+OFFICE_OF_LEADER_OF_HOUSE_OF_COMMONS = frozenset([])
+OFFICE_OF_LEADER_HOUSE_OF_LORDS = frozenset([])
+OFFICE_OF_SOS_SCOTLAND = frozenset([])
+OFFICE_OF_SOS_WALES = frozenset([])
+UK_EXPORT_FINANCE = frozenset([])
 
 # Non-ministerial departments
 
-CHARITY_COMMISSION = []
-
-COMPETITION_MARKETS_AUTHORITY = []
-CROWN_PROSECUTION_SERVICE = []
-FOOD_STANDARDS_AGENCY = []
-FORESTRY_COMMISSION = []
-
-GOV_ACTUARY_DEPT = []
-GOV_LEGAL_DEPT = []
-HM_LAND_REGISTRY = []
-HMRC = []
-NS_AND_I = []
-NATIONAL_ARCHIVES = []
-NATIONAL_CRIME_AGENCY = []
-OFFICE_OF_RAIL_AND_ROAD = []
-OFGEM = []
-OFQUAL = []
-OFSTED = []
-SERIOUS_FRAUD_OFFICE = []
-SUPREME_COURT_UK = []
-UK_STATISTICS_AUTHORITY = []
-WATER_SERVICES_REGULATION_AUTHORITY = []
+CHARITY_COMMISSION = frozenset([])
+COMPETITION_MARKETS_AUTHORITY = frozenset([])
+CROWN_PROSECUTION_SERVICE = frozenset([])
+FOOD_STANDARDS_AGENCY = frozenset([])
+FORESTRY_COMMISSION = frozenset([])
+GOV_ACTUARY_DEPT = frozenset([])
+GOV_LEGAL_DEPT = frozenset([])
+HM_LAND_REGISTRY = frozenset([])
+HMRC = frozenset([])
+NS_AND_I = frozenset([])
+NATIONAL_ARCHIVES = frozenset([])
+NATIONAL_CRIME_AGENCY = frozenset([])
+OFFICE_OF_RAIL_AND_ROAD = frozenset([])
+OFGEM = frozenset([])
+OFQUAL = frozenset([])
+OFSTED = frozenset([])
+SERIOUS_FRAUD_OFFICE = frozenset([])
+SUPREME_COURT_UK = frozenset([])
+UK_STATISTICS_AUTHORITY = frozenset([])
+WATER_SERVICES_REGULATION_AUTHORITY = frozenset([])
 
 # Devolved administrations
 
-SCOTTISH_GOVERNMENT = []
-WELSH_GOVERNMENT = []
-NI_GOVERNMENT = []  # Note, this is
+SCOTTISH_GOVERNMENT = frozenset([])
+WELSH_GOVERNMENT = frozenset([])
+NI_GOVERNMENT = frozenset([])  # Note, this is not part of UK Civil Service
+
+
+# All domains
+CIVIL_SERVICE_DOMAINS = frozenset.union(
+    ATTORNEY_GENERALS_OFFICE,
+    CABINET_OFFICE,
+    DEPT_FOR_BUSINESS_AND_TRADE,
+    DEPT_FOR_CULTURE_MEDIA_SPORT,
+    DEPT_FOR_EDUCATION,
+    DEPT_FOR_ENERGY_SECURITY_NET_ZERO,
+    DEFRA,
+    DLUHC,
+    DEPT_SCIENCE_INNOVATION_TECHNOLOGY,
+    DEPT_TRANSPORT,
+    DEPT_WORK_PENSIONS,
+    DEPT_HEALTH_SOCIAL_CARE,
+    FOREIGN_OFFICE,
+    HMT,
+    HOME_OFFICE,
+    MINISTRY_OF_DEFENCE,
+    MINISTRY_OF_JUSTICE,
+    NI_OFFICE,
+    OFFICE_OF_ADVOCATE_GENERAL_FOR_SCOTLAND,
+    OFFICE_OF_LEADER_OF_HOUSE_OF_COMMONS,
+    OFFICE_OF_LEADER_HOUSE_OF_LORDS,
+    OFFICE_OF_SOS_SCOTLAND,
+    OFFICE_OF_SOS_WALES,
+    UK_EXPORT_FINANCE,
+    CHARITY_COMMISSION,
+    COMPETITION_MARKETS_AUTHORITY,
+    CROWN_PROSECUTION_SERVICE,
+    FOOD_STANDARDS_AGENCY,
+    FORESTRY_COMMISSION,
+    GOV_ACTUARY_DEPT,
+    GOV_LEGAL_DEPT,
+    HM_LAND_REGISTRY,
+    HMRC,
+    NS_AND_I,
+    NATIONAL_ARCHIVES,
+    NATIONAL_CRIME_AGENCY,
+    OFFICE_OF_RAIL_AND_ROAD,
+    OFGEM,
+    OFQUAL,
+    OFSTED,
+    SERIOUS_FRAUD_OFFICE,
+    SUPREME_COURT_UK,
+    UK_STATISTICS_AUTHORITY,
+    WATER_SERVICES_REGULATION_AUTHORITY,
+    SCOTTISH_GOVERNMENT,
+    WELSH_GOVERNMENT,
+    NI_GOVERNMENT,
+)

--- a/etf/evaluation/restrict_email.py
+++ b/etf/evaluation/restrict_email.py
@@ -4,10 +4,8 @@ from django.forms import ValidationError
 
 def clean_email(email):
     email = email.lower()
-    email_allowed = False
-    if not email_allowed:
-        domain = email.split("@")[-1]
-        email_allowed = domain in settings.ALLOWED_DOMAINS
+    domain = email.split("@")[-1]
+    email_allowed = domain in settings.ALLOWED_DOMAINS
     if not email_allowed:
         raise ValidationError(
             "This email domain is not yet supported. Please contact the site admin team if you think this is incorrect."

--- a/etf/evaluation/restrict_email.py
+++ b/etf/evaluation/restrict_email.py
@@ -2,20 +2,9 @@ from django.conf import settings
 from django.forms import ValidationError
 
 
-def is_gov_uk(email):
-    allowed = False
-    email = email.lower()
-    email_split = email.split(".")
-    if len(email_split) > 1:
-        if email_split[-2] == "gov" and email_split[-1] == "uk":
-            allowed = True
-    return allowed
-
-
 def clean_email(email):
     email = email.lower()
     email_allowed = False
-    email_allowed = is_gov_uk(email)
     if not email_allowed:
         domain = email.split("@")[-1]
         email_allowed = domain in settings.ALLOWED_DOMAINS

--- a/etf/settings.py
+++ b/etf/settings.py
@@ -1,6 +1,7 @@
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from . import allowed_domains
 from .settings_base import (
     BASE_DIR,
     SECRET_KEY,
@@ -9,8 +10,6 @@ from .settings_base import (
     STATICFILES_DIRS,
     env,
 )
-from . import allowed_domains
-
 
 SECRET_KEY = SECRET_KEY
 STATIC_URL = STATIC_URL

--- a/etf/settings.py
+++ b/etf/settings.py
@@ -9,6 +9,8 @@ from .settings_base import (
     STATICFILES_DIRS,
     env,
 )
+from . import allowed_domains
+
 
 SECRET_KEY = SECRET_KEY
 STATIC_URL = STATIC_URL
@@ -183,9 +185,9 @@ ALLOW_EXAMPLE_EMAILS = env.bool("ALLOW_EXAMPLE_EMAILS", default=True)
 DEFAULT_ALLOWED_DOMAINS = frozenset([])  # TODO - more to be added
 
 if ALLOW_EXAMPLE_EMAILS:
-    ALLOWED_DOMAINS = DEFAULT_ALLOWED_DOMAINS.union({"example.com"})
+    ALLOWED_DOMAINS = allowed_domains.CIVIL_SERVICE_DOMAINS.union({"example.com"})
 else:
-    ALLOWED_DOMAINS = DEFAULT_ALLOWED_DOMAINS
+    ALLOWED_DOMAINS = allowed_domains.CIVIL_SERVICE_DOMAINS
 
 PASSWORD_RESET_TIMEOUT = 60 * 60 * 24
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,9 +1,8 @@
-from nose import with_setup
 from django.core.exceptions import ValidationError
+from nose import with_setup
 
 from etf import settings as etf_settings
-from etf.evaluation import models
-from etf.evaluation import restrict_email
+from etf.evaluation import models, restrict_email
 
 from . import utils
 

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,7 +1,9 @@
 from nose import with_setup
+from django.core.exceptions import ValidationError
 
 from etf import settings as etf_settings
 from etf.evaluation import models
+from etf.evaluation import restrict_email
 
 from . import utils
 
@@ -172,3 +174,26 @@ def test_incorrect_user_id_and_code_caught():
         "Something went wrong with this request. Please try entering your email again or login instead."
     )
     assert page.has_text("Enter another email")
+
+
+def test_correct_email_domains():
+    correct_emails = [
+        "test@education.gov.uk",
+        "test@no10.gov.uk",
+        "test@justice.gov.uk",
+        "test@beis.gov.uk",
+        "test@levellingup.gov.uk",
+    ]
+    for email in correct_emails:
+        cleaned_email = restrict_email.clean_email(email)
+        assert email == cleaned_email
+
+
+def test_incorrect_email_domains():
+    incorrect_emails = ["test@fake.gov.uk", "test@example.org"]
+    for email in incorrect_emails:
+        try:
+            cleaned_email = restrict_email.clean_email(email)
+            assert not cleaned_email
+        except ValidationError as e:
+            assert e.message.startswith("This email domain is not yet supported")


### PR DESCRIPTION
Makes a start on #392.

Turns out `gov.uk` endings do not necessarily mean that it's a civil service email address (sometimes could be local authorities).

This PR doesn't add all Civil Service email domains, but makes a start.

Will cross-check against the new list we have access to and add others in a separate PR.