### PR TITLE
Feature/605 external user

### DIFF
--- a/etf/evaluation/download_views.py
+++ b/etf/evaluation/download_views.py
@@ -7,6 +7,7 @@ from django.shortcuts import render
 from etf.evaluation.models import Evaluation
 from etf.evaluation.schemas import EvaluationSchema
 from etf.evaluation.utils import restrict_to_permitted_evaluations
+from etf.evaluation.choices import EvaluationVisibility
 
 
 @login_required
@@ -16,13 +17,12 @@ def filter_evaluations_to_download(request):
     restricted_evaluations = restrict_to_permitted_evaluations(user, qs)
     output_qs = Evaluation.objects.none()
     if "civil_service_only" in request.GET:
-        civil_service_evals = restricted_evaluations.filter(status="CIVIL_SERVICE")
+        civil_service_evals = restricted_evaluations.filter(visibility=EvaluationVisibility.CIVIL_SERVICE.value)
         output_qs = output_qs | civil_service_evals
     if "public" in request.GET:
-        public_evals = restricted_evaluations.filter(status="PUBLIC")
+        public_evals = restricted_evaluations.filter(visibility=EvaluationVisibility.PUBLIC.value)
         output_qs = output_qs | public_evals
     if "my_evaluations" in request.GET:
-        user = request.user
         user_evals = user.evaluations.all()
         output_qs = output_qs | user_evals
     return output_qs

--- a/etf/evaluation/download_views.py
+++ b/etf/evaluation/download_views.py
@@ -4,10 +4,10 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render
 
+from etf.evaluation.choices import EvaluationVisibility
 from etf.evaluation.models import Evaluation
 from etf.evaluation.schemas import EvaluationSchema
 from etf.evaluation.utils import restrict_to_permitted_evaluations
-from etf.evaluation.choices import EvaluationVisibility
 
 
 @login_required

--- a/etf/evaluation/download_views.py
+++ b/etf/evaluation/download_views.py
@@ -4,7 +4,6 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render
 
-from etf.evaluation import choices
 from etf.evaluation.models import Evaluation
 from etf.evaluation.schemas import EvaluationSchema
 from etf.evaluation.utils import restrict_to_permitted_evaluations

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -26,18 +26,6 @@ class UpdateEvaluationVisibilitySchema(marshmallow.Schema):
     status = marshmallow.fields.Str()
 
 
-# class AddUserToEvaluationSchema(marshmallow.Schema):
-#     user_id = marshmallow.fields.UUID()  # User doing adding
-#     evaluation_id = marshmallow.fields.UUID()
-#     user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)  # User being added
-
-
-# class UpdatedEvaluationUsersSchema(marshmallow.Schema):
-#     evaluation_id = marshmallow.fields.UUID()
-#     user_added_id = marshmallow.fields.UUID()
-#     is_new_user = marshmallow.fields.Boolean()
-
-
 class AddUserToEvaluationSchema(marshmallow.Schema):
     user_id = marshmallow.fields.UUID()
     evaluation_id = marshmallow.fields.UUID()
@@ -87,21 +75,6 @@ class Evaluation(Entity):
         evaluation.update_evaluation_page_status(page_name, status)
         evaluation.save()
         return evaluation
-
-    # @with_schema(load=AddUserToEvaluationSchema, dump=UpdatedEvaluationUsersSchema)
-    # @register_event("User added to evaluation")
-    # def add_user_to_evaluation(self, user_id, evaluation_id, user_to_add_data):
-    #     print("adding user...")
-    #     evaluation = models.Evaluation.objects.get(id=evaluation_id)
-    #     print(f"user_to_add_data: {user_to_add_data}")
-    #     user_added, is_new_user = models.User.objects.update_or_create(
-    #         email=user_to_add_data["email"], defaults=user_to_add_data
-    #     )
-    #     print("user_added")
-    #     print(user_added)
-    #     evaluation.users.add(user_added)
-    #     output = {"evaluation_id": evaluation_id, "user_added_id": user_added.id, "is_new_user": is_new_user}
-    #     return output
 
     @with_schema(load=AddUserToEvaluationSchema, dump=UpdatedEvaluationUsersSchema)
     @register_event("User added to evaluation")

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -87,7 +87,7 @@ class Evaluation(Entity):
         output = {"evaluation_id": evaluation_id, "user_added_id": user_added.id, "is_new_user": is_new_user}
         return output
 
-    @with_schema(load=RemoveEvaluationUserSchema, dump=schemas.UserSchema, load_many=False, dump_many=True)
+    @with_schema(load=RemoveEvaluationUserSchema, dump=schemas.UserSchema(many=True))
     @register_event("User removed from evaluation")
     def remove_user_from_evaluation(self, user_id, evaluation_id, user_to_remove_id):
         evaluation = models.Evaluation.objects.get(id=evaluation_id)

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -64,7 +64,7 @@ class Evaluation(Entity):
 
     @with_schema(load=UpdateEvaluationVisibilitySchema, dump=schemas.EvaluationSchema)
     def update_page_status(self, user_id, evaluation_id, page_name, status):
-        evaluation = models.Evaluation.objects.get(id=evaluation_id)
+        evaluation = models.Evaluation.objects.get(id=evaluation_id, users__id=user_id)
         evaluation.update_evaluation_page_status(page_name, status)
         evaluation.save()
         return evaluation

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -37,6 +37,11 @@ class UpdatedEvaluationUsersSchema(marshmallow.Schema):
     user_created = marshmallow.fields.Boolean()
 
 
+class RemoveEvaluationUserSchema(marshmallow.Schema):
+    evaluation_id = marshmallow.fields.UUID()
+    user_id = marshmallow.fields.UUID()
+
+
 class Evaluation(Entity):
     @with_schema(load=CreateEvaluationSchema, dump=schemas.EvaluationSchema)
     @register_event("Evaluation created")
@@ -77,6 +82,14 @@ class Evaluation(Entity):
         evaluation.users.add(user)
         output = {"evaluation_id": evaluation_id, "user_id": user.id, "user_created": user_created}
         return output
+
+    @with_schema(load=RemoveEvaluationUserSchema, dump=schemas.UserSchema)
+    @register_event("User removed from evaluation")
+    def remove_user_from_evaluation(self, evaluation_id, user_id):
+        evaluation = models.Evaluation.objects.get(id=evaluation_id)
+        user = models.User.objects.get(id=user_id)
+        evaluation.users.remove(user)
+        return evaluation.users.all()
 
 
 facade = Facade(evaluation=Evaluation())

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -74,7 +74,6 @@ class Evaluation(Entity):
     def add_user_to_evaluation(self, evaluation_id, user_data):
         evaluation = models.Evaluation.objects.get(id=evaluation_id)
         user, user_created = models.User.objects.update_or_create(email=user_data["email"], defaults=user_data)
-        print(f"user created: {user_created}")
         evaluation.users.add(user)
         output = {"evaluation_id": evaluation_id, "user_id": user.id, "user_created": user_created}
         return output

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -26,10 +26,21 @@ class UpdateEvaluationVisibilitySchema(marshmallow.Schema):
     status = marshmallow.fields.Str()
 
 
-class AddUserToEvaluationSchema(marshmallow.Schema):
-    user_id = marshmallow.fields.UUID()  # User doing adding
+# class AddUserToEvaluationSchema(marshmallow.Schema):
+#     user_id = marshmallow.fields.UUID()  # User doing adding
+#     evaluation_id = marshmallow.fields.UUID()
+#     user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)  # User being added
+
+
+# class UpdatedEvaluationUsersSchema(marshmallow.Schema):
+#     evaluation_id = marshmallow.fields.UUID()
+#     user_added_id = marshmallow.fields.UUID()
+#     is_new_user = marshmallow.fields.Boolean()
+
+
+class UpdateEvaluationUsersSchema(marshmallow.Schema):
     evaluation_id = marshmallow.fields.UUID()
-    user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)  # User being added
+    user_data = marshmallow.fields.Nested(schemas.UserSchema)
 
 
 class UpdatedEvaluationUsersSchema(marshmallow.Schema):
@@ -76,17 +87,26 @@ class Evaluation(Entity):
         evaluation.save()
         return evaluation
 
-    @with_schema(load=AddUserToEvaluationSchema, dump=UpdatedEvaluationUsersSchema)
+    # @with_schema(load=AddUserToEvaluationSchema, dump=UpdatedEvaluationUsersSchema)
+    # @register_event("User added to evaluation")
+    # def add_user_to_evaluation(self, user_id, evaluation_id, user_to_add_data):
+    #     print("adding user...")
+    #     evaluation = models.Evaluation.objects.get(id=evaluation_id)
+    #     print(f"user_to_add_data: {user_to_add_data}")
+    #     user_added, is_new_user = models.User.objects.update_or_create(
+    #         email=user_to_add_data["email"], defaults=user_to_add_data
+    #     )
+    #     print("user_added")
+    #     print(user_added)
+    #     evaluation.users.add(user_added)
+    #     output = {"evaluation_id": evaluation_id, "user_added_id": user_added.id, "is_new_user": is_new_user}
+    #     return output
+
+    @with_schema(load=UpdateEvaluationUsersSchema, dump=UpdatedEvaluationUsersSchema)
     @register_event("User added to evaluation")
-    def add_user_to_evaluation(self, user_id, evaluation_id, user_to_add_data):
-        print("adding user...")
+    def add_user_to_evaluation(self, evaluation_id, user_data):
         evaluation = models.Evaluation.objects.get(id=evaluation_id)
-        print(f"user_to_add_data: {user_to_add_data}")
-        user_added, is_new_user = models.User.objects.update_or_create(
-            email=user_to_add_data["email"], defaults=user_to_add_data
-        )
-        print("user_added")
-        print(user_added)
+        user_added, is_new_user = models.User.objects.update_or_create(email=user_data["email"], defaults=user_data)
         evaluation.users.add(user_added)
         output = {"evaluation_id": evaluation_id, "user_added_id": user_added.id, "is_new_user": is_new_user}
         return output

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -32,7 +32,7 @@ class AddUserToEvaluationSchema(marshmallow.Schema):
     user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)  # User being added
 
 
-class UpdatedEvaluationUsersSchema(marshmallow.Schema):
+class AddUserToEvaluationResponseSchema(marshmallow.Schema):
     evaluation_id = marshmallow.fields.UUID()
     user_added_id = marshmallow.fields.UUID()
     is_new_user = marshmallow.fields.Boolean()
@@ -76,7 +76,7 @@ class Evaluation(Entity):
         evaluation.save()
         return evaluation
 
-    @with_schema(load=AddUserToEvaluationSchema, dump=UpdatedEvaluationUsersSchema)
+    @with_schema(load=AddUserToEvaluationSchema, dump=AddUserToEvaluationResponseSchema)
     @register_event("User added to evaluation")
     def add_user_to_evaluation(self, user_id, evaluation_id, user_to_add_data):
         evaluation = models.Evaluation.objects.get(id=evaluation_id)

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -39,6 +39,7 @@ class UpdateEvaluationVisibilitySchema(marshmallow.Schema):
 
 
 class AddUserToEvaluationSchema(marshmallow.Schema):
+    user_id = marshmallow.fields.UUID()
     evaluation_id = marshmallow.fields.UUID()
     user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)
 
@@ -104,7 +105,7 @@ class Evaluation(Entity):
 
     @with_schema(load=AddUserToEvaluationSchema, dump=UpdatedEvaluationUsersSchema)
     @register_event("User added to evaluation")
-    def add_user_to_evaluation(self, evaluation_id, user_to_add_data):
+    def add_user_to_evaluation(self, user_id, evaluation_id, user_to_add_data):
         evaluation = models.Evaluation.objects.get(id=evaluation_id)
         user_added, is_new_user = models.User.objects.update_or_create(
             email=user_to_add_data["email"], defaults=user_to_add_data

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -40,7 +40,7 @@ class UpdateEvaluationVisibilitySchema(marshmallow.Schema):
 
 class UpdateEvaluationUsersSchema(marshmallow.Schema):
     evaluation_id = marshmallow.fields.UUID()
-    user_data = marshmallow.fields.Nested(schemas.UserSchema)
+    user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)
 
 
 class UpdatedEvaluationUsersSchema(marshmallow.Schema):
@@ -104,9 +104,11 @@ class Evaluation(Entity):
 
     @with_schema(load=UpdateEvaluationUsersSchema, dump=UpdatedEvaluationUsersSchema)
     @register_event("User added to evaluation")
-    def add_user_to_evaluation(self, evaluation_id, user_data):
+    def add_user_to_evaluation(self, evaluation_id, user_to_add_data):
         evaluation = models.Evaluation.objects.get(id=evaluation_id)
-        user_added, is_new_user = models.User.objects.update_or_create(email=user_data["email"], defaults=user_data)
+        user_added, is_new_user = models.User.objects.update_or_create(
+            email=user_to_add_data["email"], defaults=user_to_add_data
+        )
         evaluation.users.add(user_added)
         output = {"evaluation_id": evaluation_id, "user_added_id": user_added.id, "is_new_user": is_new_user}
         return output

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -27,9 +27,9 @@ class UpdateEvaluationVisibilitySchema(marshmallow.Schema):
 
 
 class AddUserToEvaluationSchema(marshmallow.Schema):
-    user_id = marshmallow.fields.UUID()
+    user_id = marshmallow.fields.UUID()  # User making request
     evaluation_id = marshmallow.fields.UUID()
-    user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)
+    user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)  # User being added
 
 
 class UpdatedEvaluationUsersSchema(marshmallow.Schema):

--- a/etf/evaluation/interface.py
+++ b/etf/evaluation/interface.py
@@ -38,7 +38,7 @@ class UpdateEvaluationVisibilitySchema(marshmallow.Schema):
 #     is_new_user = marshmallow.fields.Boolean()
 
 
-class UpdateEvaluationUsersSchema(marshmallow.Schema):
+class AddUserToEvaluationSchema(marshmallow.Schema):
     evaluation_id = marshmallow.fields.UUID()
     user_to_add_data = marshmallow.fields.Nested(schemas.UserSchema)
 
@@ -102,7 +102,7 @@ class Evaluation(Entity):
     #     output = {"evaluation_id": evaluation_id, "user_added_id": user_added.id, "is_new_user": is_new_user}
     #     return output
 
-    @with_schema(load=UpdateEvaluationUsersSchema, dump=UpdatedEvaluationUsersSchema)
+    @with_schema(load=AddUserToEvaluationSchema, dump=UpdatedEvaluationUsersSchema)
     @register_event("User added to evaluation")
     def add_user_to_evaluation(self, evaluation_id, user_to_add_data):
         evaluation = models.Evaluation.objects.get(id=evaluation_id)

--- a/etf/evaluation/models.py
+++ b/etf/evaluation/models.py
@@ -4,7 +4,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django_use_email_as_username.models import BaseUser, BaseUserManager
 
-from . import choices, enums
+from . import choices, enums, utils
 from .pages import EvaluationPageStatus, get_default_page_statuses
 
 
@@ -36,6 +36,7 @@ class User(BaseUser, UUIDPrimaryKeyBase):
 
     def save(self, *args, **kwargs):
         self.email = self.email.lower()
+        self.is_external_user = not utils.is_civil_service_email(self.email)
         super().save(*args, **kwargs)
 
     def has_signed_up(self):

--- a/etf/evaluation/restrict_email.py
+++ b/etf/evaluation/restrict_email.py
@@ -5,7 +5,7 @@ from django.forms import ValidationError
 def clean_email(email):
     email = email.lower()
     domain = email.split("@")[-1]
-    email_allowed = domain in settings.ALLOWED_DOMAINS
+    email_allowed = domain in settings.ALLOWED_CIVIL_SERVICE_DOMAINS
     if not email_allowed:
         raise ValidationError(
             "This email domain is not yet supported. Please contact the site admin team if you think this is incorrect."

--- a/etf/evaluation/restrict_email.py
+++ b/etf/evaluation/restrict_email.py
@@ -1,17 +1,6 @@
 from django.conf import settings
 from django.forms import ValidationError
 
-from etf.allowed_domains import CIVIL_SERVICE_DOMAINS
-
-
-def is_civil_service_email(email):
-    allowed = False
-    email = email.lower()
-    email_split = email.split("@")
-    if email_split[-1] in CIVIL_SERVICE_DOMAINS:
-        allowed = True
-    return allowed
-
 
 def clean_email(email):
     email = email.lower()

--- a/etf/evaluation/schemas.py
+++ b/etf/evaluation/schemas.py
@@ -75,6 +75,7 @@ def is_non_neg_int_or_none(value):
 
 class UserSchema(Schema):
     email = fields.Str(validate=validate_email)
+    is_external_user = fields.Boolean()
 
 
 class TimeStampedModelSchema(Schema):

--- a/etf/evaluation/schemas.py
+++ b/etf/evaluation/schemas.py
@@ -1,7 +1,8 @@
 from marshmallow import Schema, ValidationError, fields, validate
 
-from . import choices
 from etf.evaluation.restrict_email import is_civil_service_email
+
+from . import choices
 
 
 def make_values_in_choices(choices_values):

--- a/etf/evaluation/schemas.py
+++ b/etf/evaluation/schemas.py
@@ -1,6 +1,6 @@
 from marshmallow import Schema, ValidationError, fields, validate
 
-from etf.evaluation.restrict_email import is_civil_service_email
+from etf.evaluation.utils import is_civil_service_email
 
 from . import choices
 

--- a/etf/evaluation/schemas.py
+++ b/etf/evaluation/schemas.py
@@ -76,7 +76,6 @@ def is_non_neg_int_or_none(value):
 
 class UserSchema(Schema):
     email = fields.Str(validate=validate_email)
-    is_external_user = fields.Boolean()
 
 
 class TimeStampedModelSchema(Schema):

--- a/etf/evaluation/schemas.py
+++ b/etf/evaluation/schemas.py
@@ -1,6 +1,7 @@
 from marshmallow import Schema, ValidationError, fields, validate
 
 from . import choices
+from etf.evaluation.restrict_email import is_civil_service_email
 
 
 def make_values_in_choices(choices_values):
@@ -10,6 +11,12 @@ def make_values_in_choices(choices_values):
                 raise ValidationError(f"All values in list should be one of: {choices_values}")
 
     return values_in_choices
+
+
+def validate_email(email):
+    if not is_civil_service_email(email):
+        raise ValidationError("This should be a valid Civil Service email")
+    return True
 
 
 class DateAndBlankField(fields.Date):
@@ -67,7 +74,7 @@ def is_non_neg_int_or_none(value):
 
 
 class UserSchema(Schema):
-    email = fields.Str()
+    email = fields.Str(validate=validate_email)
 
 
 class TimeStampedModelSchema(Schema):

--- a/etf/evaluation/utils.py
+++ b/etf/evaluation/utils.py
@@ -52,10 +52,10 @@ def _register_event(event_name, arguments):
     event.save()
 
 
-def resolve_schema(schema, many=False):
+def resolve_schema(schema):
     """Allow either a class or an instance to be passed"""
     if isinstance(schema, marshmallow.schema.SchemaMeta):
-        schema = schema(many=many)
+        schema = schema()
     return schema
 
 
@@ -94,19 +94,19 @@ def check_edit_evaluation_permission(func):
     return wrapper
 
 
-def apply_schema(schema, data, load_or_dump, many=False):
+def apply_schema(schema, data, load_or_dump):
     """Apply a schema to some data"""
     if not schema:
         return data
     if load_or_dump not in ("load", "dump"):
         raise ValueError(f"Unknown value {load_or_dump}")
     if schema:
-        schema = resolve_schema(schema, many)
+        schema = resolve_schema(schema)
         arguments = getattr(schema, load_or_dump)(data)
     return arguments
 
 
-def with_schema(default=None, load=None, dump=None, load_many=False, dump_many=False):
+def with_schema(default=None, load=None, dump=None):
     """Applies the load_schema.load on the arguments to the function,
     and dump_schema.dump on the result of the function.
 
@@ -120,9 +120,9 @@ def with_schema(default=None, load=None, dump=None, load_many=False, dump_many=F
         def _inner(*args, **kwargs):
             arguments = get_arguments(func, *args, **kwargs)
             bound_func, arguments = process_self(func, arguments)
-            arguments = apply_schema(load_schema, arguments, "load", many=load_many)
+            arguments = apply_schema(load_schema, arguments, "load")
             result = bound_func(**arguments)
-            result = apply_schema(dump_schema, result, "dump", many=dump_many)
+            result = apply_schema(dump_schema, result, "dump")
             return result
 
         return _inner

--- a/etf/evaluation/utils.py
+++ b/etf/evaluation/utils.py
@@ -7,7 +7,7 @@ import marshmallow
 from django.http import Http404
 
 from . import choices, models
-from etf.allowed_domains import CIVIL_SERVICE_DOMAINS
+from etf.settings import ALLOWED_CIVIL_SERVICE_DOMAINS
 
 
 event_names = set()
@@ -257,6 +257,6 @@ def is_civil_service_email(email):
     allowed = False
     email = email.lower()
     email_split = email.split("@")
-    if email_split[-1] in CIVIL_SERVICE_DOMAINS:
+    if email_split[-1] in ALLOWED_CIVIL_SERVICE_DOMAINS:
         allowed = True
     return allowed

--- a/etf/evaluation/utils.py
+++ b/etf/evaluation/utils.py
@@ -52,10 +52,10 @@ def _register_event(event_name, arguments):
     event.save()
 
 
-def resolve_schema(schema):
+def resolve_schema(schema, many=False):
     """Allow either a class or an instance to be passed"""
     if isinstance(schema, marshmallow.schema.SchemaMeta):
-        schema = schema()
+        schema = schema(many=many)
     return schema
 
 
@@ -94,19 +94,19 @@ def check_edit_evaluation_permission(func):
     return wrapper
 
 
-def apply_schema(schema, data, load_or_dump):
+def apply_schema(schema, data, load_or_dump, many=False):
     """Apply a schema to some data"""
     if not schema:
         return data
     if load_or_dump not in ("load", "dump"):
         raise ValueError(f"Unknown value {load_or_dump}")
     if schema:
-        schema = resolve_schema(schema)
+        schema = resolve_schema(schema, many)
         arguments = getattr(schema, load_or_dump)(data)
     return arguments
 
 
-def with_schema(default=None, load=None, dump=None):
+def with_schema(default=None, load=None, dump=None, load_many=False, dump_many=False):
     """Applies the load_schema.load on the arguments to the function,
     and dump_schema.dump on the result of the function.
 
@@ -120,9 +120,9 @@ def with_schema(default=None, load=None, dump=None):
         def _inner(*args, **kwargs):
             arguments = get_arguments(func, *args, **kwargs)
             bound_func, arguments = process_self(func, arguments)
-            arguments = apply_schema(load_schema, arguments, "load")
+            arguments = apply_schema(load_schema, arguments, "load", many=load_many)
             result = bound_func(**arguments)
-            result = apply_schema(dump_schema, result, "dump")
+            result = apply_schema(dump_schema, result, "dump", many=dump_many)
             return result
 
         return _inner

--- a/etf/evaluation/utils.py
+++ b/etf/evaluation/utils.py
@@ -6,9 +6,9 @@ import types
 import marshmallow
 from django.http import Http404
 
-from . import choices, models
 from etf.settings import ALLOWED_CIVIL_SERVICE_DOMAINS
 
+from . import choices, models
 
 event_names = set()
 

--- a/etf/evaluation/utils.py
+++ b/etf/evaluation/utils.py
@@ -7,6 +7,8 @@ import marshmallow
 from django.http import Http404
 
 from . import choices, models
+from etf.allowed_domains import CIVIL_SERVICE_DOMAINS
+
 
 event_names = set()
 
@@ -249,3 +251,12 @@ def check_evaluation_view_permission(func):
             return func(request, *args, **kwargs)
 
     return wrapper
+
+
+def is_civil_service_email(email):
+    allowed = False
+    email = email.lower()
+    email_split = email.split("@")
+    if email_split[-1] in CIVIL_SERVICE_DOMAINS:
+        allowed = True
+    return allowed

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -166,16 +166,18 @@ def my_evaluations_view(request):
 @require_http_methods(["GET", "POST", "DELETE"])
 class EvaluationContributor(MethodDispatcher):
     def get(self, request, evaluation_id):
+        errors = {}
         evaluation = models.Evaluation.objects.get(pk=evaluation_id)
         users = evaluation.users.all()
-        return render(request, "contributors/contributors.html", {"contributors": users, "evaluation": evaluation})
+        return render(
+            request,
+            "contributors/contributors.html",
+            {"contributors": users, "evaluation": evaluation, "errors": errors},
+        )
 
     def post(self, request, evaluation_id):
-        evaluation = models.Evaluation.objects.get(pk=evaluation_id)
-        print("request")
-        print(request.POST)
-
         errors = {}
+        evaluation = models.Evaluation.objects.get(pk=evaluation_id)
         try:
             serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
             user_email = serialized_user["email"]
@@ -194,7 +196,6 @@ class EvaluationContributor(MethodDispatcher):
         except ValidationError as err:
             errors = dict(err.messages)
         users = evaluation.users.all()
-        print(errors)
         return render(
             request,
             "contributors/contributors.html",

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -15,7 +15,7 @@ from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
-from .utils import is_civil_service_email, restrict_to_permitted_evaluations
+from .utils import restrict_to_permitted_evaluations
 
 
 class MethodDispatcher:
@@ -180,10 +180,6 @@ class EvaluationContributor(MethodDispatcher):
         evaluation = models.Evaluation.objects.get(pk=evaluation_id)
         try:
             serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
-            user_email = serialized_user["email"]
-            # At the moment only have civil servant users, but this ensures works fine when external
-            is_external_user = not is_civil_service_email(user_email)
-            serialized_user["is_external_user"] = is_external_user
             output = interface.facade.evaluation.add_user_to_evaluation(
                 evaluation_id=evaluation_id, user_data=serialized_user
             )

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -179,9 +179,9 @@ class EvaluationContributor(MethodDispatcher):
         errors = {}
         evaluation = models.Evaluation.objects.get(pk=evaluation_id)
         try:
-            serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
+            serialized_user_to_add = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
             output = interface.facade.evaluation.add_user_to_evaluation(
-                evaluation_id=evaluation_id, user_to_add_data=serialized_user
+                user_id=request.user.id, evaluation_id=evaluation_id, user_to_add_data=serialized_user_to_add
             )
             user_added = models.User.objects.get(id=output["user_added_id"])
             if output["is_new_user"]:

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -172,6 +172,9 @@ class EvaluationContributor(MethodDispatcher):
 
     def post(self, request, evaluation_id):
         evaluation = models.Evaluation.objects.get(pk=evaluation_id)
+        print("request")
+        print(request.POST)
+
         errors = {}
         try:
             serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
@@ -191,7 +194,12 @@ class EvaluationContributor(MethodDispatcher):
         except ValidationError as err:
             errors = dict(err.messages)
         users = evaluation.users.all()
-        return render(request, "contributors/contributors.html", {"contributors": users, "evaluation": evaluation})
+        print(errors)
+        return render(
+            request,
+            "contributors/contributors.html",
+            {"contributors": users, "evaluation": evaluation, "errors": errors},
+        )
 
 
 @login_required

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -201,12 +201,12 @@ class EvaluationContributor(MethodDispatcher):
 @login_required
 @require_http_methods(["POST", "GET"])
 def evaluation_contributor_remove_view(request, evaluation_id, email_to_remove):
-    evaluation = models.Evaluation.objects.get(pk=evaluation_id)
     if request.method == "POST":
         email = email_to_remove
-        user = models.User.objects.get(email=email)
-        evaluation.users.remove(user)
-        evaluation.save()
-        if request.user == user:
+        user_to_remove = models.User.objects.get(email=email)
+        interface.facade.evaluation.remove_user_from_evaluation(
+            user_id=request.user.id, evaluation_id=evaluation_id, user_to_remove_id=user_to_remove.id
+        )
+        if request.user == user_to_remove:
             return redirect("index")
         return redirect("evaluation-contributors", evaluation_id=evaluation_id)

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -15,8 +15,7 @@ from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
-from .restrict_email import is_civil_service_email
-from .utils import restrict_to_permitted_evaluations
+from .utils import restrict_to_permitted_evaluations, is_civil_service_email
 
 
 class MethodDispatcher:

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -181,7 +181,7 @@ class EvaluationContributor(MethodDispatcher):
         try:
             serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
             output = interface.facade.evaluation.add_user_to_evaluation(
-                evaluation_id=evaluation_id, user_data=serialized_user
+                evaluation_id=evaluation_id, user_to_add_data=serialized_user
             )
             user_added = models.User.objects.get(id=output["user_added_id"])
             if output["is_new_user"]:

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -180,15 +180,14 @@ class EvaluationContributor(MethodDispatcher):
         evaluation = models.Evaluation.objects.get(pk=evaluation_id)
         try:
             serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
-            print(f"serialized user: {serialized_user}")
             output = interface.facade.evaluation.add_user_to_evaluation(
-                user_id=request.user, evaluation_id=evaluation_id, user_to_add_data=serialized_user
+                evaluation_id=evaluation_id, user_data=serialized_user
             )
-            added_user = models.User.objects.get(id=output["user_added_id"])
+            user_added = models.User.objects.get(id=output["user_added_id"])
             if output["is_new_user"]:
-                send_invite_email(added_user)
+                send_invite_email(user_added)
             else:
-                send_contributor_added_email(added_user, evaluation_id)
+                send_contributor_added_email(user_added, evaluation_id)
         except ValidationError as err:
             errors = dict(err.messages)
         users = evaluation.users.all()
@@ -197,6 +196,29 @@ class EvaluationContributor(MethodDispatcher):
             "contributors/contributors.html",
             {"contributors": users, "evaluation": evaluation, "errors": errors},
         )
+
+    # def post(self, request, evaluation_id):
+    #     errors = {}
+    #     evaluation = models.Evaluation.objects.get(pk=evaluation_id)
+    #     try:
+    #         serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
+    #         print(f"serialized user: {serialized_user}")
+    #         output = interface.facade.evaluation.add_user_to_evaluation(
+    #             user_id=request.user, evaluation_id=evaluation_id, user_to_add_data=serialized_user
+    #         )
+    #         added_user = models.User.objects.get(id=output["user_added_id"])
+    #         if output["is_new_user"]:
+    #             send_invite_email(added_user)
+    #         else:
+    #             send_contributor_added_email(added_user, evaluation_id)
+    #     except ValidationError as err:
+    #         errors = dict(err.messages)
+    #     users = evaluation.users.all()
+    #     return render(
+    #         request,
+    #         "contributors/contributors.html",
+    #         {"contributors": users, "evaluation": evaluation, "errors": errors},
+    #     )
 
 
 @login_required

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -8,14 +8,15 @@ from django.db.models import Q
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.views.decorators.http import require_http_methods
-from marshmallow.exceptions import ValidationError
 from marshmallow import EXCLUDE
+from marshmallow.exceptions import ValidationError
+
+from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
 from .restrict_email import is_civil_service_email
 from .utils import restrict_to_permitted_evaluations
-from etf.evaluation import schemas, interface
 
 
 class MethodDispatcher:

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -15,7 +15,7 @@ from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
-from .utils import restrict_to_permitted_evaluations, is_civil_service_email
+from .utils import is_civil_service_email, restrict_to_permitted_evaluations
 
 
 class MethodDispatcher:

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -180,15 +180,15 @@ class EvaluationContributor(MethodDispatcher):
         evaluation = models.Evaluation.objects.get(pk=evaluation_id)
         try:
             serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
+            print(f"serialized user: {serialized_user}")
             output = interface.facade.evaluation.add_user_to_evaluation(
-                evaluation_id=evaluation_id, user_data=serialized_user
+                user_id=request.user, evaluation_id=evaluation_id, user_to_add_data=serialized_user
             )
-            is_new_user = output["user_created"]
-            user = models.User.objects.get(id=output["user_id"])
-            if is_new_user:
-                send_invite_email(user)
+            added_user = models.User.objects.get(id=output["user_added_id"])
+            if output["is_new_user"]:
+                send_invite_email(added_user)
             else:
-                send_contributor_added_email(user, evaluation_id)
+                send_contributor_added_email(added_user, evaluation_id)
         except ValidationError as err:
             errors = dict(err.messages)
         users = evaluation.users.all()

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -197,29 +197,6 @@ class EvaluationContributor(MethodDispatcher):
             {"contributors": users, "evaluation": evaluation, "errors": errors},
         )
 
-    # def post(self, request, evaluation_id):
-    #     errors = {}
-    #     evaluation = models.Evaluation.objects.get(pk=evaluation_id)
-    #     try:
-    #         serialized_user = schemas.UserSchema().load(request.POST, unknown=EXCLUDE)
-    #         print(f"serialized user: {serialized_user}")
-    #         output = interface.facade.evaluation.add_user_to_evaluation(
-    #             user_id=request.user, evaluation_id=evaluation_id, user_to_add_data=serialized_user
-    #         )
-    #         added_user = models.User.objects.get(id=output["user_added_id"])
-    #         if output["is_new_user"]:
-    #             send_invite_email(added_user)
-    #         else:
-    #             send_contributor_added_email(added_user, evaluation_id)
-    #     except ValidationError as err:
-    #         errors = dict(err.messages)
-    #     users = evaluation.users.all()
-    #     return render(
-    #         request,
-    #         "contributors/contributors.html",
-    #         {"contributors": users, "evaluation": evaluation, "errors": errors},
-    #     )
-
 
 @login_required
 @require_http_methods(["POST", "GET"])

--- a/etf/settings.py
+++ b/etf/settings.py
@@ -188,7 +188,6 @@ LOGIN_REDIRECT_URL = "index"
 
 ALLOW_EXAMPLE_EMAILS = env.bool("ALLOW_EXAMPLE_EMAILS", default=True)
 
-DEFAULT_ALLOWED_DOMAINS = frozenset([])  # TODO - more to be added
 
 if ALLOW_EXAMPLE_EMAILS:
     ALLOWED_CIVIL_SERVICE_DOMAINS = allowed_domains.CIVIL_SERVICE_DOMAINS.union({"example.com"})

--- a/etf/settings.py
+++ b/etf/settings.py
@@ -191,9 +191,10 @@ ALLOW_EXAMPLE_EMAILS = env.bool("ALLOW_EXAMPLE_EMAILS", default=True)
 DEFAULT_ALLOWED_DOMAINS = frozenset([])  # TODO - more to be added
 
 if ALLOW_EXAMPLE_EMAILS:
-    ALLOWED_DOMAINS = allowed_domains.CIVIL_SERVICE_DOMAINS.union({"example.com"})
+    ALLOWED_CIVIL_SERVICE_DOMAINS = allowed_domains.CIVIL_SERVICE_DOMAINS.union({"example.com"})
+    # This is domain is used for testing, so for these purposes, count it as a CS domain
 else:
-    ALLOWED_DOMAINS = allowed_domains.CIVIL_SERVICE_DOMAINS
+    ALLOWED_CIVIL_SERVICE_DOMAINS = allowed_domains.CIVIL_SERVICE_DOMAINS
 
 PASSWORD_RESET_TIMEOUT = 60 * 60 * 24
 

--- a/etf/templates/contributors/contributors.html
+++ b/etf/templates/contributors/contributors.html
@@ -24,11 +24,11 @@
 
   <form method="POST" class="invite-collaborator space-between" style="align-items: end;">{{csrf_input}}
 
-    <div class="form-group full-width mb-0">
+    <div class="form-group {% if errors.get("email", []) %}error{% endif %} full-width mb-0">
       <label for="email">Email</label>
       <input aria-labelledby="add-heading" id="add-user-email" type="email" class="full-width" value="" name="email" placeholder="Contributors email..." required>
       {% if errors.get("email", []) %}
-        <div class="helper">{{errors.get("email")}}</div>
+        <div class="helper">{{errors.get("email")|join(" ")}}</div>
       {% endif %}
     </div>
     <button type="submit" class="bttn-primary">Invite collaborator</button>

--- a/etf/templates/contributors/contributors.html
+++ b/etf/templates/contributors/contributors.html
@@ -25,8 +25,8 @@
   <form method="POST" class="invite-collaborator space-between" style="align-items: end;">{{csrf_input}}
 
     <div class="form-group full-width mb-0">
-      <label for="add-user-email">Email</label>
-      <input aria-labelledby="add-heading" id="add-user-email" type="email" class="full-width" value="" name="add-user-email" placeholder="Contributors email..." required>
+      <label for="email">Email</label>
+      <input aria-labelledby="add-heading" id="add-user-email" type="email" class="full-width" value="" name="email" placeholder="Contributors email..." required>
     </div>
     <button type="submit" class="bttn-primary">Invite collaborator</button>
    </form>

--- a/etf/templates/contributors/contributors.html
+++ b/etf/templates/contributors/contributors.html
@@ -27,6 +27,9 @@
     <div class="form-group full-width mb-0">
       <label for="email">Email</label>
       <input aria-labelledby="add-heading" id="add-user-email" type="email" class="full-width" value="" name="email" placeholder="Contributors email..." required>
+      {% if errors.get("email", []) %}
+        <div class="helper">{{errors.get("email")}}</div>
+      {% endif %}
     </div>
     <button type="submit" class="bttn-primary">Invite collaborator</button>
    </form>

--- a/etf/templates/contributors/contributors.html
+++ b/etf/templates/contributors/contributors.html
@@ -25,8 +25,8 @@
   <form method="POST" class="invite-collaborator space-between" style="align-items: end;">{{csrf_input}}
 
     <div class="form-group {% if errors.get("email", []) %}error{% endif %} full-width mb-0">
-      <label for="email">Email</label>
-      <input aria-labelledby="add-heading" id="add-user-email" type="email" class="full-width" value="" name="email" placeholder="Contributors email..." required>
+      <label for="add-user-email">Email</label>
+      <input id="add-user-email" type="email" class="full-width" value="" name="email" placeholder="Contributors email..." required>
       {% if errors.get("email", []) %}
         <div class="helper">{{errors.get("email")|join(" ")}}</div>
       {% endif %}

--- a/tests/test_enter_evaluation.py
+++ b/tests/test_enter_evaluation.py
@@ -9,6 +9,7 @@ from . import utils
 
 def setup_eval():
     user, _ = models.User.objects.get_or_create(email="peter.rabbit@example.com")
+    user.set_password("pink-elephant")
     user.save()
     evaluation = models.Evaluation(title="An Evaluation")
     evaluation.save()
@@ -511,3 +512,16 @@ def complete_verify_multiple_object_page(page, title, new_item_name, added_item_
     assert not object_deleted_summary_page.has_text(new_item_name)
     assert not object_deleted_summary_page.has_text(added_item_name)
     return object_deleted_summary_page.click(contains="Next")
+
+
+@with_setup(setup_eval, teardown_eval)
+def test_invite_collaborators():
+    client = utils.make_testino_client()
+    utils.register(client, email="test-contributors@example.com", password="pink-elephants")
+    user = models.User.objects.get(email="test-contributors@example.com")
+    evaluation = models.Evaluation.objects.first()
+    evaluation.users.add(user)
+    evaluation_id = evaluation.id
+    evaluation_page = client.get(f"/evaluation/{evaluation_id}/")
+    assert evaluation_page.status_code == 200
+    # TODO - add actually inviting collaborators!

--- a/tests/test_enter_evaluation.py
+++ b/tests/test_enter_evaluation.py
@@ -524,12 +524,15 @@ def test_invite_collaborators():
     evaluation_id = evaluation.id
     contributor_page = client.get(f"/evaluation-contributors/{evaluation_id}/")
     assert contributor_page.status_code == 200
-    # TODO - add actually inviting collaborators!
+    # Check adding valid and invalid emails
     form = contributor_page.get_form("""form:not([action])""")
-    form.set(field_name="add-user-email", value="nina@example.com")
+    form.set(field_name="email", value="nina@example.com")
     response = form.submit()
     assert response.status_code == 200
     assert response.has_text("nina@example.com")
-
-
-# TODO
+    form = response.get_form("""form:not([action])""")
+    form.set(field_name="email", value="invalid@example.org")
+    response = form.submit()
+    assert response.status_code == 200
+    assert response.has_text("This should be a valid Civil Service email")
+    assert not response.has_text("invalid@example.org")

--- a/tests/test_enter_evaluation.py
+++ b/tests/test_enter_evaluation.py
@@ -522,6 +522,14 @@ def test_invite_collaborators():
     evaluation = models.Evaluation.objects.first()
     evaluation.users.add(user)
     evaluation_id = evaluation.id
-    evaluation_page = client.get(f"/evaluation/{evaluation_id}/")
-    assert evaluation_page.status_code == 200
+    contributor_page = client.get(f"/evaluation-contributors/{evaluation_id}/")
+    assert contributor_page.status_code == 200
     # TODO - add actually inviting collaborators!
+    form = contributor_page.get_form("""form:not([action])""")
+    form.set(field_name="add-user-email", value="nina@example.com")
+    response = form.submit()
+    assert response.status_code == 200
+    assert response.has_text("nina@example.com")
+
+
+# TODO

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -24,10 +24,8 @@ def test_evaluation_facade():
     assert result["user_created"], result
     assert result["evaluation_id"] == evaluation_id, result
 
-    data = {
-        "evaluation_id": evaluation_id,
-        "user_data": {"email": "mr_interface_test@example.com"},
-    }
-    result = interface.facade.evaluation.add_user_to_evaluation(data)
+    result = interface.facade.evaluation.add_user_to_evaluation(
+        evaluation_id=evaluation_id, user_data={"email": "mr_interface_test@example.com"}
+    )
     assert not result["user_created"], result
     assert result["evaluation_id"] == evaluation_id, result

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -18,8 +18,9 @@ def test_evaluation_facade():
     assert result["title"] == "Flibble"
     assert result["monetisation_approaches"] == "Sell, sell, sell"
 
-    data = {"evaluation_id": evaluation_id, "user_data": {"email": "new_user@example.com"}}
-    result = interface.facade.evaluation.add_user_to_evaluation(data)
+    result = interface.facade.evaluation.add_user_to_evaluation(
+        evaluation_id=evaluation_id, user_data={"email": "new_user@example.com"}
+    )
     assert result["user_created"], result
     assert result["evaluation_id"] == evaluation_id, result
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -6,7 +6,7 @@ USER_DATA = {"email": "mr_interface_test@example.com", "password": "1-h4t3-p455w
 def test_evaluation_facade():
     user, _ = models.User.objects.get_or_create(email=USER_DATA["email"])
     result = interface.facade.evaluation.create(user_id=user.id)
-    expected = [{"email": "mr_interface_test@example.com"}]
+    expected = [{"email": "mr_interface_test@example.com", "is_external_user": False}]
     assert result["users"] == expected, result["users"]
 
     evaluation_id = result["id"]

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,6 @@
 from etf.evaluation import interface, models
 
+
 USER_DATA = {"email": "mr_interface_test@example.com", "password": "1-h4t3-p455w0rd-c0mpl3xity-53tt1ng5"}
 
 
@@ -37,6 +38,3 @@ def test_evaluation_facade():
     user_emails = [x["email"] for x in result]
     assert "new_user@example.com" not in user_emails, user_emails
     assert "mr_interface_test@example.com" in user_emails, user_emails
-
-
-# TODO - more tests for load/dump

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -19,13 +19,21 @@ def test_evaluation_facade():
     assert result["monetisation_approaches"] == "Sell, sell, sell"
 
     result = interface.facade.evaluation.add_user_to_evaluation(
-        evaluation_id=evaluation_id, user_data={"email": "new_user@example.com"}
+        evaluation_id=evaluation_id, user_id=user.id, user_to_add_data={"email": "new_user@example.com"}
     )
-    assert result["user_created"], result
+    assert result["is_new_user"], result
     assert result["evaluation_id"] == evaluation_id, result
+    new_user_id = result["user_added_id"]
 
     result = interface.facade.evaluation.add_user_to_evaluation(
-        evaluation_id=evaluation_id, user_data={"email": "mr_interface_test@example.com"}
+        user_id=user.id, evaluation_id=evaluation_id, user_to_add_data={"email": "mr_interface_test@example.com"}
     )
-    assert not result["user_created"], result
+    assert not result["is_new_user"], result
     assert result["evaluation_id"] == evaluation_id, result
+
+    result = interface.facade.evaluation.remove_user_from_evaluation(
+        user_id=user.id, evaluation_id=evaluation_id, user_to_remove_id=new_user_id
+    )
+    user_emails = [x["email"] for x in result]
+    assert "new_user@example.com" not in user_emails, user_emails
+    assert "mr_interface_test@example.com" in user_emails, user_emails

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,6 +1,5 @@
 from etf.evaluation import interface, models
 
-
 USER_DATA = {"email": "mr_interface_test@example.com", "password": "1-h4t3-p455w0rd-c0mpl3xity-53tt1ng5"}
 
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -37,3 +37,6 @@ def test_evaluation_facade():
     user_emails = [x["email"] for x in result]
     assert "new_user@example.com" not in user_emails, user_emails
     assert "mr_interface_test@example.com" in user_emails, user_emails
+
+
+# TODO - more tests for load/dump

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -11,10 +11,22 @@ def test_evaluation_facade():
 
     evaluation_id = result["id"]
     result = interface.facade.evaluation.get(user_id=user.id, evaluation_id=evaluation_id)
-
     assert result["users"] == expected
 
     data = {"title": "Flibble", "monetisation_approaches": "Sell, sell, sell"}
     result = interface.facade.evaluation.update(user_id=user.id, evaluation_id=evaluation_id, data=data)
     assert result["title"] == "Flibble"
     assert result["monetisation_approaches"] == "Sell, sell, sell"
+
+    data = {"evaluation_id": evaluation_id, "user_data": {"email": "new_user@example.com", "is_external_user": False}}
+    result = interface.facade.evaluation.add_user_to_evaluation(data)
+    assert result["user_created"], result
+    assert result["evaluation_id"] == evaluation_id, result
+
+    data = {
+        "evaluation_id": evaluation_id,
+        "user_data": {"email": "mr_interface_test@example.com", "is_external_user": False},
+    }
+    result = interface.facade.evaluation.add_user_to_evaluation(data)
+    assert not result["user_created"], result
+    assert result["evaluation_id"] == evaluation_id, result

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -6,7 +6,7 @@ USER_DATA = {"email": "mr_interface_test@example.com", "password": "1-h4t3-p455w
 def test_evaluation_facade():
     user, _ = models.User.objects.get_or_create(email=USER_DATA["email"])
     result = interface.facade.evaluation.create(user_id=user.id)
-    expected = [{"email": "mr_interface_test@example.com", "is_external_user": False}]
+    expected = [{"email": "mr_interface_test@example.com"}]
     assert result["users"] == expected, result["users"]
 
     evaluation_id = result["id"]
@@ -18,14 +18,14 @@ def test_evaluation_facade():
     assert result["title"] == "Flibble"
     assert result["monetisation_approaches"] == "Sell, sell, sell"
 
-    data = {"evaluation_id": evaluation_id, "user_data": {"email": "new_user@example.com", "is_external_user": False}}
+    data = {"evaluation_id": evaluation_id, "user_data": {"email": "new_user@example.com"}}
     result = interface.facade.evaluation.add_user_to_evaluation(data)
     assert result["user_created"], result
     assert result["evaluation_id"] == evaluation_id, result
 
     data = {
         "evaluation_id": evaluation_id,
-        "user_data": {"email": "mr_interface_test@example.com", "is_external_user": False},
+        "user_data": {"email": "mr_interface_test@example.com"},
     }
     result = interface.facade.evaluation.add_user_to_evaluation(data)
     assert not result["user_created"], result

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -54,7 +54,11 @@ def test_search_text():
 
 
 def test_user_save():
-    new_email = "New_User1@example.org"
-    new_user, _ = models.User.objects.update_or_create(email=new_email)
-    assert new_user.email == "new_user1@example.org", new_user.email
-    assert new_user.is_external_user == True, new_user.is_external_user
+    new_email1 = "New_User1@example.org"
+    new_email2 = "New_User2@Example.com"
+    new_user1, _ = models.User.objects.update_or_create(email=new_email1)
+    new_user2, _ = models.User.objects.update_or_create(email=new_email2)
+    assert new_user1.email == "new_user1@example.org", new_user1.email
+    assert new_user1.is_external_user, new_user1.is_external_user
+    assert new_user2.email == "new_user2@example.com", new_user2.email
+    assert not new_user2.is_external_user, new_user2.is_external_user

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,3 +51,10 @@ def test_search_text():
     assert "DfE" in search_text, search_text
     assert "My new outcome measure" in search_text, search_text
     assert "Cost-benefit analysis" in search_text, search_text
+
+
+def test_user_save():
+    new_email = "New_User1@example.org"
+    new_user, _ = models.User.objects.update_or_create(email=new_email)
+    assert new_user.email == "new_user1@example.org", new_user.email
+    assert new_user.is_external_user == True, new_user.is_external_user

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -112,19 +112,14 @@ def test_verify_email():
     assert signed_up_page.has_text("A verification email has been sent to your email address.")
 
     verify_url = utils._get_latest_email_url()
-
     verify_page = client.get(verify_url)
-
     assert verify_page.has_text("Your account has been successfully verified.")
 
     login_page = client.get("/accounts/login/")
-
     form = login_page.get_form()
     form["login"] = "test-verification@example.com"
     form["password"] = VALID_USER_PASSWORD1
-
     home_page = form.submit().follow()
-
     assert home_page.has_text("Create evaluation")
 
 
@@ -137,30 +132,21 @@ def test_password_reset():
     form = page.get_form()
     form["email"] = VALID_USER_EMAIL
     page = form.submit()
-
     assert page.has_text("Please check your email for a link to reset your password.")
 
     url = utils._get_latest_email_url()
-
     page = client.get(url)
-
     form = page.get_form()
     form["password1"] = VALID_USER_PASSWORD2
     form["password2"] = VALID_USER_PASSWORD2
-
     page = form.submit()
-
     assert page.has_text("Your password has been successfully updated, please login again.")
 
     page = client.get("/accounts/login/")
-
     form = page.get_form()
-
     form["login"] = VALID_USER_EMAIL
     form["password"] = VALID_USER_PASSWORD2
-
     page = form.submit().follow()
-
     assert page.has_text("Create evaluation")
 
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -123,3 +123,18 @@ def test_evaluation_schema():
     except ValidationError as e:
         error_message = e.messages["evaluation_type"][0]
     assert error_message == "All values in list should be one of: ('IMPACT', 'PROCESS', 'ECONOMIC', 'OTHER')"
+
+
+def test_user_schema():
+    user_schema = schemas.UserSchema()
+    error_message = ""
+    try:
+        user_schema.load({"email": "invalid@example.org"})
+    except ValidationError as e:
+        error_message = e.messages["email"][0]
+    assert error_message == "This should be a valid Civil Service email", error_message
+    try:
+        user_schema.load({"email": "p"})
+    except ValidationError as e:
+        error_message = e.messages["email"][0]
+    assert error_message == "This should be a valid Civil Service email", error_message

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,6 @@ from etf.evaluation import models, utils
 from .utils import (
     create_fake_evaluations,
     remove_fake_evaluations,
-    with_authenticated_client,
 )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,8 +104,8 @@ def test_dictify():
 @with_setup(create_fake_evaluations, remove_fake_evaluations)
 def test_restrict_to_permitted_evaluations():
     all_evaluations = models.Evaluation.objects.all()
-    peter_rabbit = models.User.objects.get(email="peter.rabbit@example.com")
-    mrs_tiggywinkle = models.User.objects.get(email="mrs.tiggywinkle@example.com")
+    peter_rabbit = models.User.objects.get(email="peter.rabbit2@example.com")
+    mrs_tiggywinkle = models.User.objects.get(email="mrs.tiggywinkle@example.org")
 
     qs = test_restrict_to_permitted_evaluations(peter_rabbit, all_evaluations)
     expected_viewable_evaluation_titles = set(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,11 @@ import datetime
 import itertools
 
 import marshmallow
-from nose.tools import assert_raises
+from nose.tools import assert_raises, with_setup
 
 from etf.evaluation import utils
+from etf.evaluation import models
+from .utils import with_authenticated_client, create_fake_evaluations, remove_fake_evaluations
 
 
 def test_get_arguments():
@@ -97,3 +99,38 @@ def test_dictify():
     res = do_numbers(11)
     expected = {"0": 0, "5": 1, "10": 2}
     assert res == expected, (res, expected)
+
+
+@with_setup(create_fake_evaluations, remove_fake_evaluations)
+@with_authenticated_client
+def test_restrict_to_permitted_evaluations(client):
+    all_evaluations = models.Evaluation.objects.all()
+    user = models.User.objects.get(email="peter.rabbit@example.com")
+    user.is_external_user = True
+    user.save()
+
+    qs = test_restrict_to_permitted_evaluations(user, all_evaluations)
+    expected_viewable_evaluation_titles = set(
+        "Draft evaluation 2",
+        "Civil Service evaluation 1",
+        "Civil Service evaluation 2",
+        "Public evaluation 1",
+        "Public evaluation 2",
+    )
+    actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
+    assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
+    assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
+
+    user.is_external_user = False
+    user.save()
+    qs = test_restrict_to_permitted_evaluations(user, all_evaluations)
+    expected_viewable_evaluation_titles = set(
+        "Draft evaluation 2",
+        "Civil Service evaluation 2",
+        "Public evaluation 1",
+        "Public evaluation 2",
+    )
+    actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
+    assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
+    assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
+    assert "Civil Service evaluation 1" not in expected_viewable_evaluation_titles

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,7 @@ from nose.tools import assert_raises, with_setup
 
 from etf.evaluation import models, utils
 
-from .utils import (
-    create_fake_evaluations,
-    remove_fake_evaluations,
-)
+from .utils import create_fake_evaluations, remove_fake_evaluations
 
 
 def test_get_arguments():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,14 +106,12 @@ def test_dictify():
 
 
 @with_setup(create_fake_evaluations, remove_fake_evaluations)
-@with_authenticated_client
-def test_restrict_to_permitted_evaluations(client):
+def test_restrict_to_permitted_evaluations():
     all_evaluations = models.Evaluation.objects.all()
-    user = models.User.objects.get(email="peter.rabbit@example.com")
-    user.is_external_user = True
-    user.save()
+    peter_rabbit = models.User.objects.get(email="peter.rabbit@example.com")
+    mrs_tiggywinkle = models.User.objects.get(email="mrs.tiggywinkle@example.com")
 
-    qs = test_restrict_to_permitted_evaluations(user, all_evaluations)
+    qs = test_restrict_to_permitted_evaluations(peter_rabbit, all_evaluations)
     expected_viewable_evaluation_titles = set(
         "Draft evaluation 2",
         "Civil Service evaluation 1",
@@ -125,9 +123,7 @@ def test_restrict_to_permitted_evaluations(client):
     assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
 
-    user.is_external_user = False
-    user.save()
-    qs = test_restrict_to_permitted_evaluations(user, all_evaluations)
+    qs = test_restrict_to_permitted_evaluations(mrs_tiggywinkle, all_evaluations)
     expected_viewable_evaluation_titles = set(
         "Draft evaluation 2",
         "Civil Service evaluation 2",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import marshmallow
 from nose.tools import assert_raises, with_setup
 
 from etf.evaluation import models, utils
-
+from etf.evaluation.utils import restrict_to_permitted_evaluations
 from .utils import create_fake_evaluations, remove_fake_evaluations
 
 
@@ -107,7 +107,7 @@ def test_restrict_to_permitted_evaluations():
     peter_rabbit = models.User.objects.get(email="peter.rabbit2@example.com")
     mrs_tiggywinkle = models.User.objects.get(email="mrs.tiggywinkle@example.org")
 
-    qs = test_restrict_to_permitted_evaluations(peter_rabbit, all_evaluations)
+    qs = restrict_to_permitted_evaluations(peter_rabbit, all_evaluations)
     expected_viewable_evaluation_titles = set(
         "Draft evaluation 2",
         "Civil Service evaluation 1",
@@ -119,7 +119,7 @@ def test_restrict_to_permitted_evaluations():
     assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
 
-    qs = test_restrict_to_permitted_evaluations(mrs_tiggywinkle, all_evaluations)
+    qs = restrict_to_permitted_evaluations(mrs_tiggywinkle, all_evaluations)
     expected_viewable_evaluation_titles = set(
         "Draft evaluation 2",
         "Civil Service evaluation 2",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,13 @@ import itertools
 import marshmallow
 from nose.tools import assert_raises, with_setup
 
-from etf.evaluation import utils
-from etf.evaluation import models
-from .utils import with_authenticated_client, create_fake_evaluations, remove_fake_evaluations
+from etf.evaluation import models, utils
+
+from .utils import (
+    create_fake_evaluations,
+    remove_fake_evaluations,
+    with_authenticated_client,
+)
 
 
 def test_get_arguments():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,24 +108,15 @@ def test_restrict_to_permitted_evaluations():
     mrs_tiggywinkle = models.User.objects.get(email="mrs.tiggywinkle@example.org")
 
     qs = restrict_to_permitted_evaluations(peter_rabbit, all_evaluations)
-    expected_viewable_evaluation_titles = set(
-        "Draft evaluation 2",
-        "Civil Service evaluation 1",
-        "Civil Service evaluation 2",
-        "Public evaluation 1",
-        "Public evaluation 2",
-    )
+    expected_viewable_evaluation_titles = {"Draft evaluation 2", "Civil Service evaluation 1",
+                                           "Civil Service evaluation 2", "Public evaluation 1", "Public evaluation 2"}
     actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
     assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
 
     qs = restrict_to_permitted_evaluations(mrs_tiggywinkle, all_evaluations)
-    expected_viewable_evaluation_titles = set(
-        "Draft evaluation 2",
-        "Civil Service evaluation 2",
-        "Public evaluation 1",
-        "Public evaluation 2",
-    )
+    expected_viewable_evaluation_titles = {"Draft evaluation 2", "Civil Service evaluation 2", "Public evaluation 1",
+                                           "Public evaluation 2"}
     actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
     assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from nose.tools import assert_raises, with_setup
 
 from etf.evaluation import models, utils
 from etf.evaluation.utils import restrict_to_permitted_evaluations
+
 from .utils import create_fake_evaluations, remove_fake_evaluations
 
 
@@ -108,15 +109,24 @@ def test_restrict_to_permitted_evaluations():
     mrs_tiggywinkle = models.User.objects.get(email="mrs.tiggywinkle@example.org")
 
     qs = restrict_to_permitted_evaluations(peter_rabbit, all_evaluations)
-    expected_viewable_evaluation_titles = {"Draft evaluation 2", "Civil Service evaluation 1",
-                                           "Civil Service evaluation 2", "Public evaluation 1", "Public evaluation 2"}
+    expected_viewable_evaluation_titles = {
+        "Draft evaluation 2",
+        "Civil Service evaluation 1",
+        "Civil Service evaluation 2",
+        "Public evaluation 1",
+        "Public evaluation 2",
+    }
     actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
     assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
 
     qs = restrict_to_permitted_evaluations(mrs_tiggywinkle, all_evaluations)
-    expected_viewable_evaluation_titles = {"Draft evaluation 2", "Civil Service evaluation 2", "Public evaluation 1",
-                                           "Public evaluation 2"}
+    expected_viewable_evaluation_titles = {
+        "Draft evaluation 2",
+        "Civil Service evaluation 2",
+        "Public evaluation 1",
+        "Public evaluation 2",
+    }
     actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
     assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,6 +108,7 @@ def test_restrict_to_permitted_evaluations():
     peter_rabbit = models.User.objects.get(email="peter.rabbit2@example.com")
     mrs_tiggywinkle = models.User.objects.get(email="mrs.tiggywinkle@example.org")
 
+    assert "Draft evaluation 1" in all_evaluations.values_list("title", flat=True)
     qs = restrict_to_permitted_evaluations(peter_rabbit, all_evaluations)
     expected_viewable_evaluation_titles = {
         "Draft evaluation 2",
@@ -117,7 +118,9 @@ def test_restrict_to_permitted_evaluations():
         "Public evaluation 2",
     }
     actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
-    assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
+    assert expected_viewable_evaluation_titles.issubset(
+        actual_viewable_evaluation_titles
+    ), actual_viewable_evaluation_titles.symmetric_difference(actual_viewable_evaluation_titles)
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
 
     qs = restrict_to_permitted_evaluations(mrs_tiggywinkle, all_evaluations)
@@ -128,6 +131,6 @@ def test_restrict_to_permitted_evaluations():
         "Public evaluation 2",
     }
     actual_viewable_evaluation_titles = set(qs.values_list("title", flat=True))
-    assert expected_viewable_evaluation_titles == actual_viewable_evaluation_titles
+    assert expected_viewable_evaluation_titles.issubset(actual_viewable_evaluation_titles)
     assert "Draft evaluation 1" not in expected_viewable_evaluation_titles
     assert "Civil Service evaluation 1" not in expected_viewable_evaluation_titles

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,19 +99,23 @@ def create_fake_evaluations():
     draft_1 = Evaluation(title="Draft evaluation 1", status=choices.EvaluationStatus.DRAFT)
     draft_1.save()
     draft_2 = Evaluation(title="Draft evaluation 2", status=choices.EvaluationStatus.DRAFT)
+    draft_2.save()
     draft_2.users.add(peter_rabbit)
     draft_2.users.add(mrs_tiggywinkle)
     draft_2.save()
     cs_1 = Evaluation(title="Civil Service evaluation 1", status=choices.EvaluationStatus.CIVIL_SERVICE)
     cs_1.save()
     cs_2 = Evaluation(title="Civil Service evaluation 2", status=choices.EvaluationStatus.CIVIL_SERVICE)
+    cs_2.save()
     cs_2.users.add(peter_rabbit)
     cs_2.users.add(mrs_tiggywinkle)
     cs_2.save()
     public_1 = Evaluation(title="Public evaluation 1", status=choices.EvaluationStatus.PUBLIC)
     public_1.save()
     public_2 = Evaluation(title="Public evaluation 2", status=choices.EvaluationStatus.PUBLIC)
+    public_2.save()
     public_2.users.add(peter_rabbit)
+    public_2.save()
 
 
 def remove_fake_evaluations():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,7 +99,6 @@ def create_fake_evaluation(title, visibility, users=None):
         for user in users:
             evaluation.users.add(user)
             evaluation.save()
-    print(evaluation)
     return evaluation
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -94,7 +94,7 @@ def _get_latest_email_url():
 
 def create_fake_evaluations():
     # For testing "example.com" is counted as "Civil Service", "example.org" is not
-    peter_rabbit, _ = User.objects.update_or_create(email="peter.rabbit@example.com")
+    peter_rabbit, _ = User.objects.update_or_create(email="peter.rabbit2@example.com")
     mrs_tiggywinkle, _ = User.objects.update_or_create(email="mrs.tiggywinkle@example.org")
     draft_1 = Evaluation(title="Draft evaluation 1", status=choices.EvaluationStatus.DRAFT)
     draft_1.save()
@@ -124,4 +124,4 @@ def remove_fake_evaluations():
         "Public evaluation 2",
     ]
     Evaluation.objects.filter(title__in=fake_evaluation_titles).delete()
-    User.objects.filter(email__in=["mrs.tiggywinkle@example.com", "peter.rabbit@exaple."]).delete()
+    User.objects.filter(email__in=["mrs.tiggywinkle@example.com", "peter.rabbit2@example."]).delete()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,8 @@ import testino
 
 import etf.wsgi
 from etf import settings
-from etf.evaluation.models import User
+from etf.evaluation import choices
+from etf.evaluation.models import User, Evaluation
 
 TEST_SERVER_URL = "http://etf-testserver:8010/"
 
@@ -89,3 +90,33 @@ def _get_latest_email_url():
     whole_url = email_url.strip(",")
     url = f"/{whole_url.split('http://localhost:8010/')[-1]}".replace("?", "?")
     return url
+
+
+def create_fake_evaluations():
+    user, _ = User.objects.update_or_create(email="peter.rabbit@example.com")
+    draft_1 = Evaluation(title="Draft evaluation 1", status=choices.EvaluationStatus.DRAFT)
+    draft_1.save()
+    draft_2 = Evaluation(title="Draft evaluation 2", status=choices.EvaluationStatus.DRAFT)
+    draft_2.users.add(user)
+    draft_2.save()
+    cs_1 = Evaluation(title="Civil Service evaluation 1", status=choices.EvaluationStatus.CIVIL_SERVICE)
+    cs_1.save()
+    cs_2 = Evaluation(title="Civil Service evaluation 2", status=choices.EvaluationStatus.CIVIL_SERVICE)
+    cs_2.users.add(user)
+    cs_2.save()
+    public_1 = Evaluation(title="Public evaluation 1", status=choices.EvaluationStatus.PUBLIC)
+    public_1.save()
+    public_2 = Evaluation(title="Public evaluation 2", status=choices.EvaluationStatus.PUBLIC)
+    public_2.users.add(user)
+
+
+def remove_fake_evaluations():
+    fake_evaluation_titles = [
+        "Draft evaluation 1",
+        "Draft evaluation 2",
+        "Civil Service evaluation 1",
+        "Civil Service evaluation 2",
+        "Public evaluation 1",
+        "Public evaluation 2",
+    ]
+    Evaluation.objects.filter(title__in=fake_evaluation_titles).delete()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -93,21 +93,25 @@ def _get_latest_email_url():
 
 
 def create_fake_evaluations():
-    user, _ = User.objects.update_or_create(email="peter.rabbit@example.com")
+    # For testing "example.com" is counted as "Civil Service", "example.org" is not
+    peter_rabbit, _ = User.objects.update_or_create(email="peter.rabbit@example.com")
+    mrs_tiggywinkle, _ = User.objects.update_or_create(email="mrs.tiggywinkle@example.org")
     draft_1 = Evaluation(title="Draft evaluation 1", status=choices.EvaluationStatus.DRAFT)
     draft_1.save()
     draft_2 = Evaluation(title="Draft evaluation 2", status=choices.EvaluationStatus.DRAFT)
-    draft_2.users.add(user)
+    draft_2.users.add(peter_rabbit)
+    draft_2.users.add(mrs_tiggywinkle)
     draft_2.save()
     cs_1 = Evaluation(title="Civil Service evaluation 1", status=choices.EvaluationStatus.CIVIL_SERVICE)
     cs_1.save()
     cs_2 = Evaluation(title="Civil Service evaluation 2", status=choices.EvaluationStatus.CIVIL_SERVICE)
-    cs_2.users.add(user)
+    cs_2.users.add(peter_rabbit)
+    cs_2.users.add(mrs_tiggywinkle)
     cs_2.save()
     public_1 = Evaluation(title="Public evaluation 1", status=choices.EvaluationStatus.PUBLIC)
     public_1.save()
     public_2 = Evaluation(title="Public evaluation 2", status=choices.EvaluationStatus.PUBLIC)
-    public_2.users.add(user)
+    public_2.users.add(peter_rabbit)
 
 
 def remove_fake_evaluations():
@@ -120,3 +124,4 @@ def remove_fake_evaluations():
         "Public evaluation 2",
     ]
     Evaluation.objects.filter(title__in=fake_evaluation_titles).delete()
+    User.objects.filter(email__in=["mrs.tiggywinkle@example.com", "peter.rabbit@exaple."]).delete()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -92,30 +92,34 @@ def _get_latest_email_url():
     return url
 
 
+def create_fake_evaluation(title, visibility, users=None):
+    evaluation = Evaluation(title=title, visibility=visibility)
+    evaluation.save()
+    if users:
+        for user in users:
+            evaluation.users.add(user)
+            evaluation.save()
+    print(evaluation)
+    return evaluation
+
+
 def create_fake_evaluations():
     # For testing "example.com" is counted as "Civil Service", "example.org" is not
     peter_rabbit, _ = User.objects.update_or_create(email="peter.rabbit2@example.com")
     mrs_tiggywinkle, _ = User.objects.update_or_create(email="mrs.tiggywinkle@example.org")
-    draft_1 = Evaluation(title="Draft evaluation 1", status=choices.EvaluationStatus.DRAFT)
-    draft_1.save()
-    draft_2 = Evaluation(title="Draft evaluation 2", status=choices.EvaluationStatus.DRAFT)
-    draft_2.save()
-    draft_2.users.add(peter_rabbit)
-    draft_2.users.add(mrs_tiggywinkle)
-    draft_2.save()
-    cs_1 = Evaluation(title="Civil Service evaluation 1", status=choices.EvaluationStatus.CIVIL_SERVICE)
-    cs_1.save()
-    cs_2 = Evaluation(title="Civil Service evaluation 2", status=choices.EvaluationStatus.CIVIL_SERVICE)
-    cs_2.save()
-    cs_2.users.add(peter_rabbit)
-    cs_2.users.add(mrs_tiggywinkle)
-    cs_2.save()
-    public_1 = Evaluation(title="Public evaluation 1", status=choices.EvaluationStatus.PUBLIC)
-    public_1.save()
-    public_2 = Evaluation(title="Public evaluation 2", status=choices.EvaluationStatus.PUBLIC)
-    public_2.save()
-    public_2.users.add(peter_rabbit)
-    public_2.save()
+    users = [peter_rabbit, mrs_tiggywinkle]
+    create_fake_evaluation(title="Draft evaluation 1", visibility=choices.EvaluationVisibility.DRAFT.value)
+    create_fake_evaluation(title="Draft evaluation 2", visibility=choices.EvaluationVisibility.DRAFT.value, users=users)
+    create_fake_evaluation(
+        title="Civil Service evaluation 1", visibility=choices.EvaluationVisibility.CIVIL_SERVICE.value
+    )
+    create_fake_evaluation(
+        title="Civil Service evaluation 2", visibility=choices.EvaluationVisibility.CIVIL_SERVICE.value, users=users
+    )
+    create_fake_evaluation(title="Public evaluation 1", visibility=choices.EvaluationVisibility.PUBLIC.value)
+    create_fake_evaluation(
+        title="Public evaluation 2", visibility=choices.EvaluationVisibility.PUBLIC.value, users=users
+    )
 
 
 def remove_fake_evaluations():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ import testino
 import etf.wsgi
 from etf import settings
 from etf.evaluation import choices
-from etf.evaluation.models import User, Evaluation
+from etf.evaluation.models import Evaluation, User
 
 TEST_SERVER_URL = "http://etf-testserver:8010/"
 


### PR DESCRIPTION
Fixes #605 

Will wait for Jas' changes to adding collaborators to be merged in first and need to fix test (but ok to start reviewing now).

This PR makes the following main change:
- Turn off ability to add external users (has left in some functionality eg if you are an external user, how evals are filtered etc)

Additionally, some tidying/refactoring:
- Updated save in user to automatically determine if someone is external (otherwise we have to remember to check in every place where we add new users)
- Added validation for emails in schema (though this will change in future, I think cleanest for now)
- Use the same code whenever we are restricting the evaluations we are allowed to view (data download, search results etc)
- Added more tests




