### PR TITLE
Change summary and overview page order

### DIFF
--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -645,6 +645,15 @@ def evaluation_cost_page_view(request, evaluation_id, evaluation_cost_id):
     return response
 
 
+def filter_evaluation_overview_users_view(request, evaluation_id):
+    user = request.user
+    evaluation = interface.facade.evaluation.get(user.id, evaluation_id)
+    email_exists = any(email['email'] == user.email for email in evaluation["users"])
+    if email_exists:
+        return redirect("evaluation-overview", evaluation_id)
+    return redirect("evaluation-summary", evaluation_id)
+
+
 def evaluation_overview_view(request, evaluation_id):
     user = request.user
     evaluation = interface.facade.evaluation.get(user.id, evaluation_id)

--- a/etf/templates/evaluation-list.html
+++ b/etf/templates/evaluation-list.html
@@ -14,7 +14,7 @@
 <div class="card-results">
   {% for evaluation in evaluations %}
 
-  <a href="{{url('evaluation-summary', evaluation.id)}}" class="basic-link">
+  <a href="{{url('evaluation-overview', evaluation.id)}}" class="basic-link">
     <div class="card small">
       <header class="space-between mb-16" style="align-items: flex-start">
         <h3 class="header4 mb-8">

--- a/etf/templates/overview/evaluation-overview-analysis.html
+++ b/etf/templates/overview/evaluation-overview-analysis.html
@@ -14,7 +14,7 @@
       <button type="submit" class="bttn-primary small">Search</button>
     </form>
     <a href="#" class="bttn-tertiary small">Contact</a>
-    {% if data.user_can_edit %}<a href="{{url('intro', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
+    {% if data.user_can_edit %}<a href="{{url('evaluation-overview', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
   </div>
 </div>
 

--- a/etf/templates/overview/evaluation-overview-costs.html
+++ b/etf/templates/overview/evaluation-overview-costs.html
@@ -14,7 +14,7 @@
       <button type="submit" class="bttn-primary small">Search</button>
     </form>
     <a href="#" class="bttn-tertiary small">Contact</a>
-    {% if data.user_can_edit %}<a href="{{url('intro', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
+    {% if data.user_can_edit %}<a href="{{url('evaluation-overview', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
   </div>
 </div>
 

--- a/etf/templates/overview/evaluation-overview-design.html
+++ b/etf/templates/overview/evaluation-overview-design.html
@@ -14,7 +14,7 @@
       <button type="submit" class="bttn-primary small">Search</button>
     </form>
     <a href="#" class="bttn-tertiary small">Contact</a>
-    {% if data.user_can_edit %}<a href="{{url('intro', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
+    {% if data.user_can_edit %}<a href="{{url('evaluation-overview', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
   </div>
 </div>
 

--- a/etf/templates/overview/evaluation-overview-findings.html
+++ b/etf/templates/overview/evaluation-overview-findings.html
@@ -14,7 +14,7 @@
       <button type="submit" class="bttn-primary small">Search</button>
     </form>
     <a href="#" class="bttn-tertiary small">Contact</a>
-    {% if data.user_can_edit %}<a href="{{url('intro', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
+    {% if data.user_can_edit %}<a href="{{url('evaluation-overview', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
   </div>
 </div>
 

--- a/etf/templates/overview/evaluation-overview-measured.html
+++ b/etf/templates/overview/evaluation-overview-measured.html
@@ -14,7 +14,7 @@
       <button type="submit" class="bttn-primary small">Search</button>
     </form>
     <a href="#" class="bttn-tertiary small">Contact</a>
-    {% if data.user_can_edit %}<a href="{{url('intro', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
+    {% if data.user_can_edit %}<a href="{{url('evaluation-overview', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
   </div>
 </div>
 

--- a/etf/templates/overview/evaluation-overview.html
+++ b/etf/templates/overview/evaluation-overview.html
@@ -14,7 +14,7 @@
       <button type="submit" class="bttn-primary small">Search</button>
     </form>
     <a href="#" class="bttn-tertiary small">Contact</a>
-    {% if data.user_can_edit %}<a href="{{url('intro', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
+    {% if data.user_can_edit %}<a href="{{url('evaluation-overview', evaluation_id=data.evaluation.id)}}" class="bttn-tertiary small">{{macros.pencil_svg()}} Edit</a>{% endif %}
   </div>
 </div>
 

--- a/etf/templates/search-form.html
+++ b/etf/templates/search-form.html
@@ -150,7 +150,7 @@
 
         <div class="card-results">
           {% for evaluation in data.evaluations %}
-          <a href="{{url('evaluation-summary', evaluation.id)}}" class="basic-link">
+          <a href="{{url('evaluation-overview-filter-users', evaluation.id)}}" class="basic-link">
             <div class="card small">
             <h2 class="header4">{% if evaluation.title %}{{evaluation.title}}{% else %}No title provided{% endif %}</h2>
             <p>{{evaluation.brief_description}}</p>

--- a/etf/urls.py
+++ b/etf/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("search/", views.EvaluationSearchView, name="search"),
     path("my-evaluations/", views.my_evaluations_view, name="my-evaluations"),
+    path("evaluation/<uuid:evaluation_id>/overview/filter-users/", submission_views.filter_evaluation_overview_users_view, name="evaluation-overview-filter-users"),
     path(
         "evaluation/<uuid:evaluation_id>/overview/",
         submission_views.evaluation_overview_view,


### PR DESCRIPTION
- Added new page for sorting users into owners and non-owners for redirection
  - I've done it this way because an owner would be unable to ever view the preview if I sorted on that page
- Added ability to get to the summary/preview from the progress page
- Updated URLs
- Modified required links around page