### PR TITLE
Feature/759 edit access

### DIFF
--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 
 from . import choices, interface, models, pages, schemas
-from .utils import check_edit_evaluation_permission
+from .utils import check_edit_evaluation_permission, check_is_civil_service_user
 
 
 @login_required
@@ -34,6 +34,7 @@ def make_evaluation_url(evaluation_id, page_name):
 
 
 @login_required
+@check_is_civil_service_user
 def create_evaluation(request):
     if request.method == "POST":
         title = request.POST.get("title")

--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -6,7 +6,10 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 
 from . import choices, interface, models, pages, schemas
-from .utils import check_edit_evaluation_permission, check_is_civil_service_user
+from .utils import (
+    check_edit_evaluation_permission,
+    check_is_civil_service_user,
+)
 
 
 @login_required

--- a/etf/evaluation/submission_views.py
+++ b/etf/evaluation/submission_views.py
@@ -721,6 +721,8 @@ def filter_evaluation_overview_users_view(request, evaluation_id):
     return redirect("evaluation-summary", evaluation_id)
 
 
+@login_required
+@check_edit_evaluation_permission
 def evaluation_overview_view(request, evaluation_id):
     evaluation = interface.facade.evaluation.get(evaluation_id)
     relevant_pages = set().union(

--- a/etf/evaluation/utils.py
+++ b/etf/evaluation/utils.py
@@ -253,6 +253,15 @@ def check_evaluation_view_permission(func):
     return wrapper
 
 
+def check_is_civil_service_user(func):
+    def wrapper(request, *args, **kwargs):
+        if request.user.is_external_user:
+            raise Http404()
+        return func(request, *args, **kwargs)
+
+    return wrapper
+
+
 def is_civil_service_email(email):
     allowed = False
     email = email.lower()

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -16,7 +16,7 @@ from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
-from .utils import restrict_to_permitted_evaluations
+from .utils import restrict_to_permitted_evaluations, check_edit_evaluation_permission
 
 
 class MethodDispatcher:
@@ -164,6 +164,7 @@ def my_evaluations_view(request):
 
 
 @login_required
+@check_edit_evaluation_permission
 @require_http_methods(["GET", "POST", "DELETE"])
 class EvaluationContributor(MethodDispatcher):
     def get(self, request, evaluation_id):
@@ -200,6 +201,7 @@ class EvaluationContributor(MethodDispatcher):
 
 
 @login_required
+@check_edit_evaluation_permission
 @require_http_methods(["POST", "GET"])
 def evaluation_contributor_remove_view(request, evaluation_id, email_to_remove):
     if request.method == "POST":

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -16,10 +16,7 @@ from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
-from .utils import (
-    check_edit_evaluation_permission,
-    restrict_to_permitted_evaluations,
-)
+from .utils import check_edit_evaluation_permission, restrict_to_permitted_evaluations, check_is_civil_service_user
 
 
 class MethodDispatcher:
@@ -204,7 +201,7 @@ class EvaluationContributor(MethodDispatcher):
 
 
 @login_required
-@check_edit_evaluation_permission
+@check_is_civil_service_user
 @require_http_methods(["POST", "GET"])
 def evaluation_contributor_remove_view(request, evaluation_id, email_to_remove):
     if request.method == "POST":

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -16,7 +16,11 @@ from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
-from .utils import check_edit_evaluation_permission, restrict_to_permitted_evaluations, check_is_civil_service_user
+from .utils import (
+    check_edit_evaluation_permission,
+    check_is_civil_service_user,
+    restrict_to_permitted_evaluations,
+)
 
 
 class MethodDispatcher:

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -16,7 +16,10 @@ from etf.evaluation import interface, schemas
 
 from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
-from .utils import restrict_to_permitted_evaluations, check_edit_evaluation_permission
+from .utils import (
+    check_edit_evaluation_permission,
+    restrict_to_permitted_evaluations,
+)
 
 
 class MethodDispatcher:

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -18,7 +18,6 @@ from . import choices, enums, models
 from .email_handler import send_contributor_added_email, send_invite_email
 from .utils import (
     check_edit_evaluation_permission,
-    check_is_civil_service_user,
     restrict_to_permitted_evaluations,
 )
 

--- a/etf/evaluation/views.py
+++ b/etf/evaluation/views.py
@@ -205,8 +205,8 @@ class EvaluationContributor(MethodDispatcher):
 
 
 @login_required
-@check_is_civil_service_user
-@require_http_methods(["POST", "GET"])
+@check_edit_evaluation_permission
+@require_http_methods(["POST"])
 def evaluation_contributor_remove_view(request, evaluation_id, email_to_remove):
     if request.method == "POST":
         email = email_to_remove

--- a/etf/urls.py
+++ b/etf/urls.py
@@ -11,18 +11,11 @@ from etf.evaluation import (
     views,
 )
 
-urlpatterns = [
+initial_urlpatterns = [
     path("", submission_views.index_view, name="index"),
-    path("accounts/verify/", authentication_views.CustomVerifyUserEmail, name="verify-email"),
-    path("accounts/password-reset/", authentication_views.PasswordReset, name="password-reset"),
-    path("accounts/change-password/reset/", authentication_views.PasswordChange, name="password-set"),
-    path("accounts/login/", authentication_views.CustomLoginView, name="account_login"),
-    path("accounts/signup/", authentication_views.CustomSignupView.as_view(), name="account_signup"),
-    path("accounts/verify/resend/", authentication_views.CustomResendVerificationView, name="resend-verify-email"),
-    path("accounts/accept-invite/", authentication_views.AcceptInviteSignupView, name="accept-invite"),
-    path("accounts/", include("allauth.urls")),
     path("search/", views.EvaluationSearchView, name="search"),
     path("my-evaluations/", views.my_evaluations_view, name="my-evaluations"),
+    path("data-download/", download_views.download_page_view, name="data-download"),
     path(
         "evaluation/<uuid:evaluation_id>/overview/filter-users/",
         submission_views.filter_evaluation_overview_users_view,
@@ -33,7 +26,17 @@ urlpatterns = [
         submission_views.evaluation_overview_view,
         name="evaluation-overview",
     ),
-    path("data-download/", download_views.download_page_view, name="data-download"),
+]
+
+account_urlpatterns = [
+    path("accounts/verify/", authentication_views.CustomVerifyUserEmail, name="verify-email"),
+    path("accounts/password-reset/", authentication_views.PasswordReset, name="password-reset"),
+    path("accounts/change-password/reset/", authentication_views.PasswordChange, name="password-set"),
+    path("accounts/login/", authentication_views.CustomLoginView, name="account_login"),
+    path("accounts/signup/", authentication_views.CustomSignupView.as_view(), name="account_signup"),
+    path("accounts/verify/resend/", authentication_views.CustomResendVerificationView, name="resend-verify-email"),
+    path("accounts/accept-invite/", authentication_views.AcceptInviteSignupView, name="accept-invite"),
+    path("accounts/", include("allauth.urls")),
 ]
 
 evaluation_contributor_urlpatterns = [
@@ -152,6 +155,11 @@ evaluation_entry_urlpatterns = [
         name="visibility",
     ),
     path("evaluation/<uuid:evaluation_id>/end/", submission_views.end_page_view, name="end"),
+    path(
+        "evaluation/<uuid:evaluation_id>/overview/",
+        submission_views.evaluation_overview_view,
+        name="evaluation-overview",
+    ),
 ]
 
 intervention_urlpatterns = [
@@ -318,7 +326,8 @@ feedback_and_help_urlpatterns = [path("feedback-and-help/", views.feedback_and_h
 
 
 urlpatterns = (
-    urlpatterns
+    initial_urlpatterns
+    + account_urlpatterns
     + evaluation_contributor_urlpatterns
     + evaluation_entry_urlpatterns
     + intervention_urlpatterns

--- a/etf/urls.py
+++ b/etf/urls.py
@@ -324,11 +324,8 @@ evaluation_summary_urlpatterns = [
 
 feedback_and_help_urlpatterns = [path("feedback-and-help/", views.feedback_and_help_view, name="feedback-and-help")]
 
-
-urlpatterns = (
-    initial_urlpatterns
-    + account_urlpatterns
-    + evaluation_contributor_urlpatterns
+evaluation_edit_patterns = (
+    evaluation_contributor_urlpatterns
     + evaluation_entry_urlpatterns
     + intervention_urlpatterns
     + outcome_measure_urlpatterns
@@ -339,15 +336,23 @@ urlpatterns = (
     + documents_urlpatterns
     + links_urlpatterns
     + event_date_urlpatterns
+)
+
+urlpatterns = (
+    initial_urlpatterns
+    + account_urlpatterns
+    + evaluation_edit_patterns
     + evaluation_summary_urlpatterns
     + feedback_and_help_urlpatterns
 )
 
-if settings.DEBUG:
-    urlpatterns = urlpatterns + [
-        path("admin/", admin.site.urls),
-        path("test/", views.beta_test_view, name="test"),
-    ]
+debug_urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("test/", views.beta_test_view, name="test"),
+]
 
+
+if settings.DEBUG:
+    urlpatterns = urlpatterns + debug_urlpatterns
 
 handler404 = "etf.evaluation.views.view_404"

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -120,10 +120,6 @@ def test_view_not_edit_evaluations_related_objects(client):
     evaluation_public = models.Evaluation.objects.filter(title="Public evaluation 1").first()
     for evaluation in [evaluation_cs, evaluation_public]:
         for url_pattern in EDIT_EVALUATIONS:
-            response = get_url_for_evaluation_and_related_object(client, url_pattern.name, evaluation.id)
-            if response:
-                assert response.status_code == 404, response.status_code
+            check_related_objects_status(client, evaluation, expected_status=404)
         for url_pattern in VIEW_EVALUATION_URL_PATTERNS:
-            response = get_url_for_evaluation_and_related_object(client, url_pattern.name, evaluation.id)
-            if response:
-                assert response.status_code == 200, response.status_code
+            check_related_objects_status(client, evaluation, expected_status=200)

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -172,4 +172,4 @@ def test_remove_contributor(client):
     evaluation.save()
     url = reverse("evaluation-contributor-remove", args=(evaluation.id, "mrs.tiggywinkle@example.com"))
     response = client.get(url)
-    assert response.status_code == 404
+    assert response.status_code == 405, response.status_code

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -7,6 +7,21 @@ from etf.evaluation import models
 from . import utils
 
 
+# TODO - do this better
+NAMES_TO_IGNORE = [
+    "intervention-page",
+    "outcome-measure-page",
+    "other-measure-page",
+    "processes-standard-page",
+    "evaluation-cost-page",
+    "document-page",
+    "link-page",
+    "event-date-page",
+    "evaluation-contributor-remove",
+    "create-evaluation",
+    "evaluation-overview",
+]
+
 # Explicitly excluding URLs, to ensure that we don't miss out new URLs
 EDIT_OR_VIEW_EVALUATION_URL_PATTERNS = (
     set(urls.urlpatterns)
@@ -27,6 +42,9 @@ VIEW_EVALUATION_URL_PATTERNS = (
 
 
 def get_url_for_evaluation(client, url_pattern, evaluation_id):
+    name = url_pattern.name
+    if name in NAMES_TO_IGNORE:
+        return
     url = reverse(url_pattern.name, args=(evaluation_id,))
     response = client.get(url)
     return response
@@ -37,9 +55,11 @@ def get_url_for_evaluation(client, url_pattern, evaluation_id):
 def test_edit_evaluations(client):
     evaluation_not_editable = models.Evaluation.objects.filter(title="Draft evaluation 1").first()
     evaluation_editable = models.Evaluation.objects.filter(title="Draft evaluation 2").first()
-    for url_pattern in EDIT_OR_VIEW_EVALUATION_URL_PATTERNS:
-        response = get_url_for_evaluation(client, url_pattern, evaluation_editable.id)
-        assert response.status_code == 200
+    # for url_pattern in EDIT_OR_VIEW_EVALUATION_URL_PATTERNS:
+    #     response = get_url_for_evaluation(client, url_pattern, evaluation_editable.id)
+    #     if response:
+    #         assert response.status_code == 200
     for url_pattern in EDIT_OR_VIEW_EVALUATION_URL_PATTERNS:
         response = get_url_for_evaluation(client, url_pattern, evaluation_not_editable.id)
-        assert response.status_code == 404
+        if response:
+            assert response.status_code == 404

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -17,6 +17,7 @@ NAMES_TO_IGNORE = [
     "document-page",
     "link-page",
     "event-date-page",
+    "grant-page",
     "evaluation-contributor-remove",
     "create-evaluation",
     "evaluation-overview",

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -79,8 +79,9 @@ def test_edit_or_view_related_objects(client):
     evaluation_not_editable = models.Evaluation.objects.filter(title="Draft evaluation 1").first()
     for url_name, model_name in RELATED_OBJECTS.items():
         model = getattr(models, model_name)
-        new_obj = model(evaluation__id=evaluation_not_editable.id)
+        new_obj = model(evaluation=evaluation_not_editable)
         new_obj.save()
         related_id = new_obj.id
         response = get_url_for_evaluation_and_related_object(client, url_name, evaluation_not_editable.id, related_id)
-        assert response.status_code == 404, response.status_code
+        if response:
+            assert response.status_code == 404, response.status_code

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -6,7 +6,24 @@ from etf.evaluation import models
 
 from . import utils
 
-EDIT_EVALUATION_URL_PATTERNS = []
+
+# Explicitly excluding URLs, to ensure that we don't miss out new URLs
+EDIT_OR_VIEW_EVALUATION_URL_PATTERNS = (
+    set(urls.urlpatterns)
+    - set(urls.initial_urlpatterns)
+    - set(urls.account_urlpatterns)
+    - set(urls.feedback_and_help_urlpatterns)
+    - set(urls.debug_urlpatterns)
+)
+
+VIEW_EVALUATION_URL_PATTERNS = (
+    set(urls.urlpatterns)
+    - set(urls.initial_urlpatterns)
+    - set(urls.account_urlpatterns)
+    - set(urls.feedback_and_help_urlpatterns)
+    - set(urls.evaluation_edit_patterns)
+    - set(urls.debug_urlpatterns)
+)
 
 
 def get_url_for_evaluation(client, url_pattern, evaluation_id):
@@ -17,12 +34,12 @@ def get_url_for_evaluation(client, url_pattern, evaluation_id):
 
 @with_setup(utils.create_fake_evaluations, utils.remove_fake_evaluations)
 @utils.with_authenticated_client
-def test_cant_edit_evaluations(client):
+def test_edit_evaluations(client):
     evaluation_not_editable = models.Evaluation.objects.filter(title="Draft evaluation 1").first()
     evaluation_editable = models.Evaluation.objects.filter(title="Draft evaluation 2").first()
-    for url_pattern in EDIT_EVALUATION_URL_PATTERNS:
+    for url_pattern in EDIT_OR_VIEW_EVALUATION_URL_PATTERNS:
         response = get_url_for_evaluation(client, url_pattern, evaluation_editable.id)
         assert response.status_code == 200
-    for url_pattern in EDIT_EVALUATION_URL_PATTERNS:
+    for url_pattern in EDIT_OR_VIEW_EVALUATION_URL_PATTERNS:
         response = get_url_for_evaluation(client, url_pattern, evaluation_not_editable.id)
         assert response.status_code == 404

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -167,8 +167,8 @@ def test_external_evaluation_overview(client):
 @utils.with_authenticated_external_client
 def test_remove_contributor(client):
     evaluation = models.Evaluation.objects.filter(title="Civil Service evaluation 2").first()
-    user = models.Evaluation.objects.get(email="jemima.puddleduck@example.org")
-    evaluation.add(user)
+    user = models.User.objects.get(email="jemima.puddleduck@example.org")
+    evaluation.users.add(user)
     evaluation.save()
     url = reverse("evaluation-contributor-remove", args=(evaluation.id, "mrs.tiggywinkle@example.com"))
     response = client.get(url)

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -149,7 +149,7 @@ def test_internal_evaluation_overview(client):
     evaluation_draft = models.Evaluation.objects.filter(title="Draft evaluation 1").first()
     url = reverse("evaluation-overview", args=(evaluation_draft.id,))
     response = client.get(url)
-    assert response.status_code == 200
+    assert response.status_code == 404
 
 
 @with_setup(utils.create_fake_evaluations, utils.remove_fake_evaluations)
@@ -161,3 +161,15 @@ def test_external_evaluation_overview(client):
         url = reverse("evaluation-overview", args=(evaluation.id,))
         response = client.get(url)
         assert response.status_code == 404
+
+
+@with_setup(utils.create_fake_evaluations, utils.remove_fake_evaluations)
+@utils.with_authenticated_external_client
+def test_remove_contributor(client):
+    evaluation = models.Evaluation.objects.filter(title="Civil Service evaluation 2").first()
+    user = models.Evaluation.objects.get(email="jemima.puddleduck@example.org")
+    evaluation.add(user)
+    evaluation.save()
+    url = reverse("evaluation-contributor-remove", args=(evaluation.id, "mrs.tiggywinkle@example.com"))
+    response = client.get(url)
+    assert response.status_code == 404

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -1,0 +1,28 @@
+from django.urls import reverse
+from nose import with_setup
+
+from etf import urls
+from etf.evaluation import models
+
+from . import utils
+
+EDIT_EVALUATION_URL_PATTERNS = []
+
+
+def get_url_for_evaluation(client, url_pattern, evaluation_id):
+    url = reverse(url_pattern.name, args=(evaluation_id,))
+    response = client.get(url)
+    return response
+
+
+@with_setup(utils.create_fake_evaluations, utils.remove_fake_evaluations)
+@utils.with_authenticated_client
+def test_cant_edit_evaluations(client):
+    evaluation_not_editable = models.Evaluation.objects.filter(title="Draft evaluation 1").first()
+    evaluation_editable = models.Evaluation.objects.filter(title="Draft evaluation 2").first()
+    for url_pattern in EDIT_EVALUATION_URL_PATTERNS:
+        response = get_url_for_evaluation(client, url_pattern, evaluation_editable.id)
+        assert response.status_code == 200
+    for url_pattern in EDIT_EVALUATION_URL_PATTERNS:
+        response = get_url_for_evaluation(client, url_pattern, evaluation_not_editable.id)
+        assert response.status_code == 404

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -7,22 +7,6 @@ from etf.evaluation import models
 from . import utils
 
 
-# TODO - do this better
-NAMES_TO_IGNORE = [
-    "intervention-page",
-    "outcome-measure-page",
-    "other-measure-page",
-    "processes-standard-page",
-    "evaluation-cost-page",
-    "document-page",
-    "link-page",
-    "event-date-page",
-    "grant-page",
-    "evaluation-contributor-remove",
-    "create-evaluation",
-    "evaluation-overview",
-]
-
 # Explicitly excluding URLs, to ensure that we don't miss out new URLs
 EDIT_OR_VIEW_EVALUATION_URL_PATTERNS = (
     set(urls.urlpatterns)
@@ -42,25 +26,61 @@ VIEW_EVALUATION_URL_PATTERNS = (
 )
 
 
-def get_url_for_evaluation(client, url_pattern, evaluation_id):
-    name = url_pattern.name
-    if name in NAMES_TO_IGNORE:
+# Non-standard URLs - explicitly write tests
+NAMES_TO_IGNORE = [
+    "evaluation-contributor-remove",
+    "create-evaluation",
+    "evaluation-overview",
+]
+
+
+RELATED_OBJECTS = {
+    "intervention-page": "Intervention",
+    "outcome-measure-page": "OutcomeMeasure",
+    "other-measure-page": "OtherMeasure",
+    "processes-standard-page": "ProcessStandard",
+    "evaluation-cost-page": "EvaluationCost",
+    "document-page": "Document",
+    "link-page": "LinkOtherService",
+    "event-date-page": "EventDate",
+    "grant-page": "Grant",
+}
+
+
+def get_url_for_evaluation_and_related_object(client, url_name, evaluation_id, related_id=None):
+    if (url_name in NAMES_TO_IGNORE) or (url_name in RELATED_OBJECTS.keys()):
         return
-    url = reverse(url_pattern.name, args=(evaluation_id,))
+    if related_id:
+        url = reverse(url_name, args=(evaluation_id, related_id))
+    else:
+        url = reverse(url_name, args=(evaluation_id,))
     response = client.get(url)
     return response
 
 
 @with_setup(utils.create_fake_evaluations, utils.remove_fake_evaluations)
 @utils.with_authenticated_client
-def test_edit_evaluations(client):
+def test_edit_or_view_evaluations(client):
     evaluation_not_editable = models.Evaluation.objects.filter(title="Draft evaluation 1").first()
-    evaluation_editable = models.Evaluation.objects.filter(title="Draft evaluation 2").first()
-    # for url_pattern in EDIT_OR_VIEW_EVALUATION_URL_PATTERNS:
-    #     response = get_url_for_evaluation(client, url_pattern, evaluation_editable.id)
-    #     if response:
-    #         assert response.status_code == 200
     for url_pattern in EDIT_OR_VIEW_EVALUATION_URL_PATTERNS:
-        response = get_url_for_evaluation(client, url_pattern, evaluation_not_editable.id)
+        response = get_url_for_evaluation_and_related_object(client, url_pattern.name, evaluation_not_editable.id)
         if response:
-            assert response.status_code == 404
+            assert response.status_code == 404, response.status_code
+
+
+# TODO - test edit only
+
+# TODO - test can view but not edit some
+
+
+@with_setup(utils.create_fake_evaluations, utils.remove_fake_evaluations)
+@utils.with_authenticated_client
+def test_edit_or_view_related_objects(client):
+    evaluation_not_editable = models.Evaluation.objects.filter(title="Draft evaluation 1").first()
+    for url_name, model_name in RELATED_OBJECTS.items():
+        model = getattr(models, model_name)
+        new_obj = model(evaluation__id=evaluation_not_editable.id)
+        new_obj.save()
+        related_id = new_obj.id
+        response = get_url_for_evaluation_and_related_object(client, url_name, evaluation_not_editable.id, related_id)
+        assert response.status_code == 404, response.status_code

--- a/tests/test_access_evaluations.py
+++ b/tests/test_access_evaluations.py
@@ -133,3 +133,15 @@ def test_cant_edit_or_view_related_objects_external(client):
     evaluation_public = models.Evaluation.objects.filter(title="Public evaluation 1").first()
     for evaluation in [evaluation_draft, evaluation_cs, evaluation_public]:
         check_related_objects_status(client, evaluation, expected_status=404)
+
+
+@utils.with_authenticated_external_client
+def test_external_cant_create_evaluation(client):
+    response = client.get(reverse("create-evaluation"))
+    assert response.status_code == 404
+
+
+@utils.with_authenticated_client
+def test_internal_create_evaluation(client):
+    response = client.get(reverse("create-evaluation"))
+    assert response.status_code == 200


### PR DESCRIPTION
Fixes #759.

Write tests for all URLs to check only correct users can access. Write tests so that new URLs will be tested automatically. Refactor `urls.py` to make this easier.

Also fix some URLs that weren't restricted appropriately.