### PR TITLE
Fix formatting

### DIFF
--- a/etf/allowed_domains.py
+++ b/etf/allowed_domains.py
@@ -103,7 +103,9 @@ WELSH_GOVERNMENT = frozenset(["wales.gov.uk", "gov.wales"])
 NI_GOVERNMENT = frozenset(["assemblyni.gov.uk", "assembly-ni.gov.uk"])  # Note, this is not part of UK Civil Service
 
 # Other emails
-DIGITAL_ACCESSIBILITY_CENTRE = frozenset(["digitalaccessibilitycentre.org"])  # Note, for accessibility testing (to be removed once testing complete)
+DIGITAL_ACCESSIBILITY_CENTRE = frozenset(
+    ["digitalaccessibilitycentre.org"]
+)  # Note, for accessibility testing (to be removed once testing complete)
 
 # Things like profession emails, Fast Stream emails etc
 


### PR DESCRIPTION
Code checks only run when branch name has prefix `feature/` or `bugfix/` (possibly also `hotfix/`) which is why this formatting change wasn't caught before! (I should also have picked up on it in review).